### PR TITLE
Export webgl liquid glass component

### DIFF
--- a/examples/src/App.tsx
+++ b/examples/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
-import LiquidGlass, { type LiquidGlassProps } from 'simple-liquid-glass'
+import { LiquidGlass, type LiquidGlassProps } from 'simple-liquid-glass'
 
 type Mode = 'preset' | 'custom'
 type Controls = Pick<

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
-    "three": "^0.165.0"
+    "three": "^0.165.0",
+    "html2canvas": "^1.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/src/LiquidGlass.stories.tsx
+++ b/src/LiquidGlass.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import LiquidGlass, { WebGLLiquidGlass } from './index';
+import { LiquidGlass, WebGLLiquidGlass } from './index';
 
 type LiquidGlassComponent = typeof LiquidGlass;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -137,13 +137,15 @@ export interface LiquidGlassProps extends HTMLAttributes<HTMLDivElement> {
 
 export declare function LiquidGlass(props: LiquidGlassProps): JSX.Element;
 
-export default LiquidGlass;
 export interface WebGLLiquidGlassProps extends HTMLAttributes<HTMLDivElement> {
-  imageSrc: string;
+  imageSrc?: string;
   width?: number;
   height?: number;
   dpi?: number;
+  captureBackground?: boolean;
   className?: string;
   style?: CSSProperties;
 }
+
 export declare function WebGLLiquidGlass(props: WebGLLiquidGlassProps): JSX.Element;
+export default WebGLLiquidGlass;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -665,7 +665,7 @@ export function LiquidGlass({
 
 LiquidGlass.displayName = "LiquidGlass";
 
-export default LiquidGlass;
 export { default as WebGLLiquidGlass } from './webgl/WebGLLiquidGlass';
+export { default } from './webgl/WebGLLiquidGlass';
 
 // Removed non-working experimental components per user request


### PR DESCRIPTION
Export `WebGLLiquidGlass` as the default component, enabling it to capture and display its parent's background.

---
<a href="https://cursor.com/background-agent?bcId=bc-f47bd321-4775-4791-b27b-1ddfa81cc492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f47bd321-4775-4791-b27b-1ddfa81cc492">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

