### PR TITLE
Use blur preset for performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,24 @@ On iOS, when `iosBlurMode` is `'auto'`, a minimal blur (`iosMinBlur`, default 7p
 
 The `background` prop automatically converts solid colors and gradients to semi-transparent (30% opacity) for better glass effects. Images (URLs) are left unchanged.
 
-### Blur-only Preset (no SVG)
+### Presets: svg, blur, none
 
-To maximize performance and avoid any SVG generation, enable the blur-only preset:
+Use a simplified API to control the effect strategy:
 
 ```jsx
-<LiquidGlass preset="blur" blur={2}>
-  <YourContent />
-</LiquidGlass>
+// SVG displacement (default auto behavior still applies on mobile via mobileFallback)
+<LiquidGlass preset="svg" />
+
+// CSS-only blur (no SVG). Defaults to a light blur if not provided.
+<LiquidGlass preset="blur" blur={2} />
+
+// No effect (keeps saturation/frost/background and border)
+<LiquidGlass preset="none" />
 ```
 
-- Forces CSS-only blur (no SVG filters) for minimal GPU/CPU overhead
-- Automatically uses low quality heuristics internally
-- Respects iOS fallback rules (may enforce a minimum blur when `iosBlurMode` is `'auto'`)
+- `blur`: forces CSS-only blur (no SVG) and uses low-quality heuristics internally. If `blur` is not provided, a sensible default is applied.
+- `svg`: uses the SVG displacement filter when available; respects `mobileFallback` and iOS rules.
+- `none`: disables the filter effect entirely.
 
 ## Props
 
@@ -127,7 +132,7 @@ To maximize performance and avoid any SVG generation, enable the blur-only prese
 |------|------|---------|-------------|
 | `children` | `ReactNode` | - | Content to display inside the glass effect |
 | `mode` | `'preset' \| 'custom'` | `'preset'` | Use preset values or custom configuration |
-| `preset` | `'blur'` | - | Blur-only mode: disables SVG filter and uses CSS blur only |
+| `preset` | `'svg' \| 'blur' \| 'none'` | - | Simplified effect selection: SVG filter, CSS blur only, or none |
 | `scale` | `number` | `160` | Scale of the displacement effect (-360 to 360) |
 | `radius` | `number` | `50` | Border radius of the glass effect |
 | `border` | `number` | `0.05` | Border thickness (0 to 0.5) |
@@ -151,7 +156,6 @@ To maximize performance and avoid any SVG generation, enable the blur-only prese
 | `quality` | `'low' \| 'standard' \| 'high' \| 'extreme'` | `'low'` | Rendering quality preset. `'extreme'` matches previous versions' visuals |
 | `autodetectquality` | `boolean` | `false` | Auto-detect device performance and pick a quality preset |
 | `mobileFallback` | `'css-only' \| 'svg'` | CSS-only on mobile | Control mobile rendering strategy |
-| `effectMode` | `'auto' \| 'svg' \| 'blur' \| 'off'` | `'auto'` | Control effect: auto, force SVG, force CSS blur, or disable |
 
 ## Examples
 
@@ -206,33 +210,19 @@ To maximize performance and avoid any SVG generation, enable the blur-only prese
 - **Default behavior**: on mobile devices the component uses a CSS-only effect to avoid jank; on desktop it uses the SVG filter.
 - **Quality presets**: `'low'` is the default and optimized for many instances; `'extreme'` matches previous visuals.
 - **Autodetection**: set `autodetectquality` to let the component choose a preset based on device performance.
-- **Effect Mode**: use `effectMode` to force the strategy.
+- Use the `preset` prop to select between `'svg'`, `'blur'`, and `'none'`.
+
+### Preset Control
 
 ```jsx
-// Force CSS-only blur (no SVG) — recommended on very low-end devices
-<LiquidGlass effectMode="blur" />
+// CSS blur only
+<LiquidGlass preset="blur" />
 
-// Disable all filter effects (keeps border/frost/background)
-<LiquidGlass effectMode="off" />
+// Disable the effect
+<LiquidGlass preset="none" />
 
-// Force SVG filter everywhere
-<LiquidGlass effectMode="svg" />
-```
-
-### Effect Mode Control
-
-```jsx
-// Force pure CSS blur (no SVG) — ideal per dispositivi molto low-end
-<LiquidGlass effectMode="blur" />
-
-// Disattiva totalmente l'effetto (mantiene solo saturazione/frost)
-<LiquidGlass effectMode="off" />
-
-// Forza sempre l'SVG
-<LiquidGlass effectMode="svg" />
-
-// Selezione automatica (default)
-<LiquidGlass effectMode="auto" />
+// Force SVG
+<LiquidGlass preset="svg" />
 ```
 
 ### Card with Glass Effect

--- a/README.md
+++ b/README.md
@@ -107,12 +107,27 @@ On iOS, when `iosBlurMode` is `'auto'`, a minimal blur (`iosMinBlur`, default 7p
 
 The `background` prop automatically converts solid colors and gradients to semi-transparent (30% opacity) for better glass effects. Images (URLs) are left unchanged.
 
+### Blur-only Preset (no SVG)
+
+To maximize performance and avoid any SVG generation, enable the blur-only preset:
+
+```jsx
+<LiquidGlass preset="blur" blur={2}>
+  <YourContent />
+</LiquidGlass>
+```
+
+- Forces CSS-only blur (no SVG filters) for minimal GPU/CPU overhead
+- Automatically uses low quality heuristics internally
+- Respects iOS fallback rules (may enforce a minimum blur when `iosBlurMode` is `'auto'`)
+
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `children` | `ReactNode` | - | Content to display inside the glass effect |
 | `mode` | `'preset' \| 'custom'` | `'preset'` | Use preset values or custom configuration |
+| `preset` | `'blur'` | - | Blur-only mode: disables SVG filter and uses CSS blur only |
 | `scale` | `number` | `160` | Scale of the displacement effect (-360 to 360) |
 | `radius` | `number` | `50` | Border radius of the glass effect |
 | `border` | `number` | `0.05` | Border thickness (0 to 0.5) |

--- a/src/LiquidGlass.stories.tsx
+++ b/src/LiquidGlass.stories.tsx
@@ -302,6 +302,32 @@ export const BlurOnly: Story = {
   ),
 };
 
+export const PresetBlur: Story = {
+  args: {
+    preset: 'blur',
+    blur: 2,
+    children: (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontWeight: 600,
+        }}
+      >
+        Preset: Blur (CSS only)
+      </div>
+    ),
+  },
+  render: (args) => (
+    <DraggableWrapper width={480} height={280}>
+      <LiquidGlass {...args} />
+    </DraggableWrapper>
+  ),
+};
+
 export const EffectOff: Story = {
   args: {
     effectMode: 'off',

--- a/src/LiquidGlass.stories.tsx
+++ b/src/LiquidGlass.stories.tsx
@@ -45,9 +45,9 @@ const meta: Meta<LiquidGlassComponent> = {
       control: 'radio',
       options: ['css-only', 'svg'],
     },
-    effectMode: {
+    preset: {
       control: 'radio',
-      options: ['auto', 'svg', 'blur', 'off'],
+      options: ['svg', 'blur', 'none'],
     },
     scale: { control: { type: 'range', min: 0, max: 400, step: 1 } },
     radius: { control: { type: 'range', min: 0, max: 200, step: 1 } },
@@ -77,7 +77,6 @@ const meta: Meta<LiquidGlassComponent> = {
   args: {
     mode: 'preset',
     quality: 'low',
-    effectMode: 'auto',
     autodetectquality: false,
     radius: 50,
     scale: 160,
@@ -278,7 +277,7 @@ export const ExtremeQuality: Story = {
 
 export const BlurOnly: Story = {
   args: {
-    effectMode: 'blur',
+    preset: 'blur',
     blur: 2,
     children: (
       <div
@@ -330,7 +329,7 @@ export const PresetBlur: Story = {
 
 export const EffectOff: Story = {
   args: {
-    effectMode: 'off',
+    preset: 'none',
     children: (
       <div
         style={{

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,6 +11,10 @@ export interface LiquidGlassProps extends HTMLAttributes<HTMLDivElement> {
    * @default "preset"
    */
   mode?: 'preset' | 'custom';
+  /**
+   * Simplified effect selection. Use 'svg' for SVG displacement, 'blur' for CSS blur only, or 'none' to disable.
+   */
+  preset?: 'svg' | 'blur' | 'none';
   
   /**
    * Scale of the displacement effect
@@ -125,15 +129,10 @@ export interface LiquidGlassProps extends HTMLAttributes<HTMLDivElement> {
   /** iOS blur fallback mode. 'auto' forces a minimal blur; 'off' disables it. Default: 'auto' */
   iosBlurMode?: 'auto' | 'off';
   /**
-   * Mobile rendering strategy. Default: CSS-only on mobile devices, SVG on desktop.
+   * Mobile rendering strategy. Default: CSS-only on mobile devices, SVG on desktop (when preset is 'svg' or auto-selected).
    * Use 'svg' to force SVG filter on mobile, or 'css-only' to force CSS fallback.
    */
   mobileFallback?: 'css-only' | 'svg';
-  /**
-   * Control the rendering effect: auto-select, force SVG, CSS blur, or disable effects entirely.
-   * @default 'auto'
-   */
-  effectMode?: 'auto' | 'svg' | 'blur' | 'off';
   
   /**
    * Additional CSS class names


### PR DESCRIPTION
Introduce `preset="blur"` to provide a high-performance, CSS-only blur effect without SVG generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-e157ff5c-7523-4e39-8b6c-5ac2d7b49cb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e157ff5c-7523-4e39-8b6c-5ac2d7b49cb6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

