### PR TITLE
feat(refraction)!: shape adaptation, angle, lens modes + animated/interactive liquid refraction (3.0.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ Thumbs.db
 Desktop.ini
 # Claude session settings
 .claude/
+# Brainstorming mockups + local verification scratch
+.superpowers/
+verify/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,38 @@
 All notable changes to this project are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## 3.0.0 — 2026-06-17
+
+### Added
+
+- **Shape-adaptive refraction (`shapeAdapt`, default on).** The displacement map is now built in
+  aspect-true pixel space, so the lens reads like glass *cut to the element's shape* — a long
+  navbar or tall sidebar refracts evenly instead of over-bending on its short axis. Free: it lives
+  entirely in the baked map; the GPU filter graph is unchanged.
+- **Directional refraction (`angle`, degrees).** Point the refraction lean any direction. It's
+  shape-adapted, so `45°` reads as a true 45° on any aspect ratio (not a flattened lean). `0` =
+  baseline; positive = clockwise. Chromium SVG path.
+- **Lens field modes (`lens`) + manual tuning (`lensStrength`, `lensCenter`).** Choose how the glass
+  bends light: `classic` (linear radial), `convex` (one coherent dome magnifier — no top/bottom
+  split), `shift` (uniform directional offset; straight lines stay straight), or `rim` (clear flat
+  center, refraction only at a soft perimeter band). Each is a distinct displacement field with
+  fold-safe defaults at the standard `scale`.
+- **Real animated refraction (`liquid: 'ripple' | 'flow' | 'wobble'`).** The backdrop genuinely
+  warps via a live `feTurbulence` → `feDisplacementMap` stage — not a compositor overlay. Tunable
+  with `liquidSpeed` / `liquidScale`. Opt-in and GPU-gated: animates only while on-screen, pauses on
+  `prefers-reduced-motion`, Chromium-only, amplitude-capped on mobile/low quality.
+- **Pointer interaction on `LiquidGlassInteractive`:** `liquidTrigger` (`'always' | 'hover' |
+  'press'` — `hover`/`press` stay idle, zero cost, until you interact) and `followPointer` (a
+  refractive bump that distorts the backdrop toward the cursor).
+- New shared core modules `core/liquid` (preset → turbulence params, pure/tested) and
+  `normalizeAngle` in `core/displacementMap`.
+
+### Changed
+
+- **BREAKING (visual):** `shapeAdapt` defaults to `true`, which changes how **non-square** lenses
+  refract at `angle: 0` (square lenses are visually unchanged). Set `shapeAdapt={false}` to restore
+  the byte-for-byte legacy ≤2.x map.
+
 ## 2.4.0 — 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **The only zero-dependency liquid glass component with _real refraction on iPhone &amp; Safari_ — not a blur fallback. Works on React 16.8–19.**
 
-A tiny, zero-dependency **React liquid glass component**. It renders Apple-style “liquid glass” with an SVG displacement map — and, uniquely, delivers **real refraction on iOS, Safari, and Firefox**, where every other library falls back to a plain blur. Chromatic aberration, gradient borders, automatic text color, SSR-safe, plus a framework-agnostic web component — all in ~6.5 KB.
+A tiny, zero-dependency **React liquid glass component**. It renders Apple-style “liquid glass” with an SVG displacement map — and, uniquely, delivers **real refraction on iOS, Safari, and Firefox**, where every other library falls back to a plain blur. Chromatic aberration, gradient borders, automatic text color, SSR-safe, plus a framework-agnostic web component — the React core is ~10 KB (the web component ~5 KB).
 
 [![npm version](https://img.shields.io/npm/v/simple-liquid-glass)](https://www.npmjs.com/package/simple-liquid-glass)
 [![npm downloads](https://img.shields.io/npm/dw/simple-liquid-glass)](https://www.npmjs.com/package/simple-liquid-glass)
@@ -21,7 +21,7 @@ A tiny, zero-dependency **React liquid glass component**. It renders Apple-style
 |---|:--:|:--:|:--:|
 | Real refraction on **Safari / iOS** | ✅ | ❌ | ❌ (WebGL) |
 | React **16.8 – 19** | ✅ | ❌ (19 only) | ✅ |
-| Bundle (gzip) | **~6.5 KB** | ~33 KB | 6.8 MB |
+| Bundle (gzip) | **~10 KB** (web component ~5 KB) | ~33 KB | 6.8 MB |
 | Zero runtime deps | ✅ | ✅ | ❌ (Three.js) |
 | SSR-safe (Next.js) | ✅ | ⚠️ | ❌ |
 | Web component (Vue / Svelte / vanilla) | ✅ | ❌ | ❌ |
@@ -231,6 +231,16 @@ The `background` prop automatically converts solid colors and gradients to semi-
 | `autodetectquality` | `boolean` | `false` | Auto-detect device performance and pick a quality preset |
 | `mobileFallback` | `'css-only' \| 'svg'` | CSS-only on mobile | Control mobile rendering strategy |
 | `effectMode` | `'auto' \| 'svg' \| 'blur' \| 'off'` | `'auto'` | Control effect: auto, force SVG, force CSS blur, or disable |
+| `angle` | `number` | `0` | Refraction direction in degrees (in-plane lean, not light tilt). `0` = baseline; positive = clockwise. **Shape-adapted** so the on-screen angle is faithful on any aspect ratio. Chromium SVG path. |
+| `shapeAdapt` | `boolean` | `true` | Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's shape (long navbar / tall sidebar refract evenly). `false` restores the legacy ≤2.x map. |
+| `lens` | `'classic' \| 'convex' \| 'shift' \| 'rim'` | `'classic'` | Lens field shape. `classic` = linear radial; `convex` = one coherent dome magnifier (no top/bottom split); `shift` = uniform directional offset (straight stays straight); `rim` = clear flat center, refraction only at a soft perimeter band. |
+| `lensStrength` | `number` | `1` | Manual magnitude of the lens field. `0` disables the lens displacement. |
+| `lensCenter` | `[number, number]` | `[0.5, 0.5]` | Normalized `0..1` center for `convex` / `rim`. |
+| `liquid` | `'ripple' \| 'flow' \| 'wobble' \| false` | `false` | **Real animated refraction** — the backdrop genuinely warps. Opt-in, GPU-real: runs only while on-screen, pauses on `prefers-reduced-motion`, Chromium SVG path only. |
+| `liquidSpeed` | `number` | `1` | Motion rate multiplier for `liquid`. |
+| `liquidScale` | `number` | preset | Distortion amplitude (px) for `liquid`. Defaults to the preset's amplitude. |
+
+> **`LiquidGlassInteractive`** (from `simple-liquid-glass/interactive`) adds two more: `liquidTrigger` (`'always' \| 'hover' \| 'press'`, default `'always'` — `hover`/`press` stay idle until you interact) and `followPointer` (`boolean`, a refractive bump that distorts the backdrop toward the cursor).
 
 ## Examples
 

--- a/docs/frameworks/README.md
+++ b/docs/frameworks/README.md
@@ -30,4 +30,9 @@ with `backdropRef` (the live-DOM mirror isn't in the web component yet). Every g
 ```
 
 Attributes: `radius`, `frost`, `blur`, `saturation`, `displace`, `scale`, `lightness`, `alpha`,
-`border-color`. Give it an explicit size and place it over a background.
+`border-color`, `angle`, `shape-adapt`, `lens`, `lens-strength`, `lens-center`, `liquid`,
+`liquid-speed`, `liquid-scale`. Give it an explicit size and place it over a background.
+
+3.0.0 adds directional/shape-adaptive refraction (`angle`, `shape-adapt`), lens modes
+(`lens`, `lens-strength`, `lens-center`), and real animated "liquid" refraction
+(`liquid`, `liquid-speed`, `liquid-scale`).

--- a/docs/frameworks/astro.md
+++ b/docs/frameworks/astro.md
@@ -83,6 +83,14 @@ On Chromium you get real SVG-displacement refraction; on Safari/iOS/Firefox a po
 | `lightness` | number (0–100) | `53` | Glass lightness |
 | `alpha` | number (0–1) | `0.9` | Overall opacity |
 | `border-color` | CSS color | `rgba(120,120,120,0.7)` | Border color |
+| `angle` | number | `0` | **3.0** Refraction direction (degrees), shape-adapted so the on-screen angle is faithful on any aspect ratio (Chromium SVG) |
+| `shape-adapt` | `"true"` \| `"false"` | `true` | **3.0** Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's shape; `"false"` = legacy ≤2.x map |
+| `lens` | `classic` \| `convex` \| `shift` \| `rim` | `classic` | **3.0** Lens field shape — `convex` = one coherent dome magnifier, `shift` = uniform directional offset (straight lines stay straight), `rim` = clear center with refraction only at a soft perimeter band |
+| `lens-strength` | number | `1` | **3.0** Manual magnitude of the lens field; `0` disables it |
+| `lens-center` | `"x,y"` (each 0–1) | `0.5,0.5` | **3.0** Lens center for `convex`/`rim` |
+| `liquid` | `ripple` \| `flow` \| `wobble` | — | **3.0** Real animated refraction — the backdrop genuinely warps. Opt-in, GPU-real: animates only while on-screen, pauses on `prefers-reduced-motion` (Chromium SVG) |
+| `liquid-speed` | number | `1` | **3.0** Motion rate for `liquid` |
+| `liquid-scale` | number | per preset | **3.0** Distortion amplitude (px) for `liquid` |
 
 > Because it's a web component (not tied to Astro's reactivity), attribute changes after load won't re-render unless you set them via JS: `document.querySelector('liquid-glass').setAttribute('frost','0.25')`.
 

--- a/docs/frameworks/svelte.md
+++ b/docs/frameworks/svelte.md
@@ -104,6 +104,14 @@ All attributes are optional. Pass them as strings; the component parses numeric 
 | `lightness` | number | `53` | Glass lightness; `0`–`100` |
 | `alpha` | number | `0.9` | Glass opacity; `0`–`1` |
 | `border-color` | string | `rgba(120,120,120,0.7)` | CSS color (any format) |
+| `angle` | number | `0` | Refraction direction in degrees; shape-adapted so the on-screen angle is faithful on any aspect ratio (Chromium SVG path) |
+| `shape-adapt` | string | `true` | Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's shape (long navbar / tall sidebar refracts evenly); set `"false"` for the legacy ≤2.x map |
+| `lens` | string | `classic` | Lens field shape: `classic` (linear radial), `convex` (one coherent dome magnifier, no top/bottom split), `shift` (uniform directional offset, straight lines stay straight), `rim` (clear flat center, refraction only at a soft perimeter band) |
+| `lens-strength` | number | `1` | Manual magnitude of the lens field; `0` disables it |
+| `lens-center` | string | `0.5,0.5` | Lens center for `convex`/`rim`; `"x,y"` each `0`–`1` |
+| `liquid` | string | — | Real animated refraction — the backdrop genuinely warps: `ripple`, `flow`, or `wobble`. Opt-in, GPU-real: animates only while on-screen, pauses on `prefers-reduced-motion` (Chromium SVG path) |
+| `liquid-speed` | number | `1` | Motion rate for `liquid` |
+| `liquid-scale` | number | — | Distortion amplitude in px for `liquid` (defaults per preset) |
 
 ## Reactive attributes
 

--- a/docs/frameworks/vanilla.md
+++ b/docs/frameworks/vanilla.md
@@ -319,6 +319,32 @@ glass.setAttribute('alpha', '0.85');
 
 // Update border color (any CSS color string)
 glass.setAttribute('border-color', 'rgba(200, 100, 100, 0.8)');
+
+// New in 3.0.0 ---------------------------------------------------------------
+
+// Update angle (refraction direction in degrees, shape-adapted)
+glass.setAttribute('angle', '45');
+
+// Toggle shape-adapt (aspect-faithful + isotropic; "false" = legacy ≤2.x map)
+glass.setAttribute('shape-adapt', 'false');
+
+// Update lens field shape ("classic" | "convex" | "shift" | "rim")
+glass.setAttribute('lens', 'convex');
+
+// Update lens-strength (magnitude of the lens field; 0 disables it)
+glass.setAttribute('lens-strength', '1.5');
+
+// Update lens-center for convex/rim ("x,y", each 0–1)
+glass.setAttribute('lens-center', '0.3,0.7');
+
+// Update liquid (real animated refraction: "ripple" | "flow" | "wobble")
+glass.setAttribute('liquid', 'ripple');
+
+// Update liquid-speed (motion rate)
+glass.setAttribute('liquid-speed', '1.5');
+
+// Update liquid-scale (distortion amplitude in px)
+glass.setAttribute('liquid-scale', '12');
 ```
 
 ### Reading Attributes Back
@@ -360,6 +386,14 @@ All attributes are **optional**. Sensible defaults ship with the component.
 | `lightness` | number | `53` | Brightness of the glass, 0–100 (HSL lightness) |
 | `alpha` | number | `0.9` | Overall opacity of the glass layer (0–1) |
 | `border-color` | string | `"rgba(120,120,120,0.7)"` | Any valid CSS color (hex, rgb, rgba, hsl, etc.) |
+| `angle` | number | `0` | **New in 3.0.0.** Refraction direction in degrees. Shape-adapted so the on-screen angle stays faithful on any aspect ratio (Chromium SVG path) |
+| `shape-adapt` | string | `"on"` | **New in 3.0.0.** Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's shape (a long navbar / tall sidebar refracts evenly). Set `"false"` to disable and use the legacy ≤2.x map |
+| `lens` | string | `"classic"` | **New in 3.0.0.** Lens field shape: `classic` (linear radial), `convex` (one coherent dome magnifier, no top/bottom split), `shift` (uniform directional offset, straight lines stay straight), `rim` (clear flat center, refraction only at a soft perimeter band) |
+| `lens-strength` | number | `1` | **New in 3.0.0.** Manual magnitude of the lens field; `0` disables it |
+| `lens-center` | string | `"0.5,0.5"` | **New in 3.0.0.** Lens center for `convex`/`rim`, as `"x,y"` with each value 0–1 |
+| `liquid` | string | — | **New in 3.0.0.** Real animated refraction—the backdrop genuinely warps: `ripple`, `flow`, or `wobble`. Opt-in, GPU-real: animates only while on-screen, pauses on `prefers-reduced-motion`, Chromium SVG path only |
+| `liquid-speed` | number | `1` | **New in 3.0.0.** Motion rate for `liquid` |
+| `liquid-scale` | number | — | **New in 3.0.0.** Distortion amplitude in px for `liquid` (defaults per preset) |
 
 ### Default Element in Action
 
@@ -369,6 +403,9 @@ All attributes are **optional**. Sensible defaults ship with the component.
 
 <!-- Mix defaults with custom values -->
 <liquid-glass radius="24" frost="0.2">Your content</liquid-glass>
+
+<!-- New in 3.0.0: a coherent dome magnifier with a 45° refraction direction -->
+<liquid-glass radius="24" lens="convex" angle="45">Your content</liquid-glass>
 ```
 
 ---

--- a/docs/frameworks/vue.md
+++ b/docs/frameworks/vue.md
@@ -334,6 +334,14 @@ All attributes are optional and accept string or number values (custom elements 
 | `lightness` | number | `53` | 0–100 | Glass brightness/lightness |
 | `alpha` | number | `0.9` | 0–1 | Glass opacity |
 | `border-color` | string | `rgba(120,120,120,0.7)` | CSS color | Border rim color |
+| `angle` | number | `0` | 0–360 | **New in 3.0.0.** Refraction direction in degrees. Shape-adapted so the on-screen angle is faithful on any aspect ratio (Chromium SVG path) |
+| `shape-adapt` | string | `on` | `on` / `false` | **New in 3.0.0.** Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's shape (a long navbar / tall sidebar refracts evenly). Set `"false"` for the legacy ≤2.x map |
+| `lens` | string | `classic` | `classic` / `convex` / `shift` / `rim` | **New in 3.0.0.** Lens field shape. `classic` = linear radial; `convex` = one coherent dome magnifier (no top/bottom split); `shift` = uniform directional offset (straight lines stay straight); `rim` = clear flat center, refraction only at a soft perimeter band |
+| `lens-strength` | number | `1` | — | **New in 3.0.0.** Manual magnitude of the lens field; `0` disables it |
+| `lens-center` | string | `0.5,0.5` | each `0`–`1` | **New in 3.0.0.** Lens center as `"x,y"` for `convex`/`rim` |
+| `liquid` | string | — | `ripple` / `flow` / `wobble` | **New in 3.0.0.** Real animated refraction — the backdrop genuinely warps. Opt-in, GPU-real: animates only while on-screen, pauses on `prefers-reduced-motion` (Chromium SVG path only) |
+| `liquid-speed` | number | `1` | — | **New in 3.0.0.** Motion rate for `liquid` |
+| `liquid-scale` | number | per preset | — | **New in 3.0.0.** Distortion amplitude in pixels for `liquid` |
 
 ### Binding Attributes in `<script setup>`
 

--- a/docs/superpowers/specs/2026-06-17-liquid-refraction-shape-and-motion-design.md
+++ b/docs/superpowers/specs/2026-06-17-liquid-refraction-shape-and-motion-design.md
@@ -1,0 +1,95 @@
+# Liquid refraction: shape adaptation + directional angle + animated/interactive motion
+
+**Date:** 2026-06-17
+**Status:** approved — building
+**Package:** `simple-liquid-glass` → **3.0.0** (major: default visual change on non-square elements)
+**Extends / supersedes:** `2026-06-17-refraction-angle-design.md` (folds in that spec's review fixes)
+
+## Summary
+
+Three layered capabilities, built together:
+
+1. **Directional refraction** — `angle` (degrees), shape-adapted so the lean is *faithful on any aspect ratio* (a 45° reads as 45° on a wide navbar, not a flattened ~18°).
+2. **Shape adaptation (default ON)** — the lens reads like glass *cut to the element's shape*: faithful angle + isotropic refraction (equal lensing strength on both axes). This changes how existing **non-square** lenses look even at `angle: 0` → hence the major version. `shapeAdapt={false}` restores the legacy map byte-for-byte.
+3. **Real animated refraction** — GPU-driven liquid motion presets (`ripple | flow | wobble`) plus pointer interaction (`liquidTrigger`, `followPointer`) on `LiquidGlassInteractive`. The backdrop genuinely warps; this is not a compositor overlay trick.
+
+## API surface
+
+### `LiquidGlass` (base) — static + autoplay motion
+| prop | type | default | meaning |
+|---|---|---|---|
+| `angle` | `number` | `0` | refraction direction in degrees; `0` = baseline; positive = clockwise (SVG y-down). In-plane rotation of the lean, not light-incidence. For `lens: 'shift'` it is the offset direction. |
+| `shapeAdapt` | `boolean` | `true` | aspect-faithful + isotropic refraction. `false` = legacy non-adapted map (byte-identical to ≤2.x). |
+| `lens` | `'classic' \| 'convex' \| 'shift' \| 'rim'` | `'classic'` | lens field shape (see Lens modes below). |
+| `lensStrength` | `number` | `1` | manual magnitude of the lens field; `0` disables it. |
+| `lensCenter` | `[number, number]` | `[0.5, 0.5]` | normalized center for `convex` / `rim`. |
+| `liquid` | `'ripple' \| 'flow' \| 'wobble' \| false` | `false` | real animated refraction preset (opt-in, GPU-real). |
+| `liquidSpeed` | `number` | `1` | motion rate multiplier. |
+| `liquidScale` | `number` | preset | distortion amplitude (px of displacement). |
+
+### `LiquidGlassInteractive` — adds pointer reactivity (already owns pointer tracking)
+| prop | type | default | meaning |
+|---|---|---|---|
+| `liquidTrigger` | `'always' \| 'hover' \| 'press'` | `'always'` | when the liquid animates; `hover`/`press` are idle (zero cost) until interaction. |
+| `followPointer` | `boolean` | `false` | a refractive bump that distorts toward the cursor (eased). |
+
+## Mechanism
+
+### Shape-adapted directional map — FREE (`src/core/displacementMap.ts`)
+The cost-free half. Lives entirely in the baked displacement map; the GPU filter graph is unchanged.
+
+- **Gradients move to `gradientUnits="userSpaceOnUse"`** in the aspect-preserving viewBox pixel space.
+- **Faithful angle:** `gradientTransform="rotate(angle cx cy)"` about the pixel center → a true on-screen angle on any aspect ratio (rotation happens in real pixel space, not the normalized unit square).
+- **Isotropic refraction:** each ramp's amplitude is scaled so the per-pixel displacement *slope* matches on both axes — the long axis keeps full amplitude, the short axis is scaled by `shortExtent / longestExtent`. This removes the over-bending on the short axis of a wide/tall element.
+- **`normalizeAngle(angle)`**: non-finite → 0; wrap to `[0,360)`; round to 3 decimals. Used for both the SVG and the React cache key, so `360`/`NaN`/`45.0000001` collapse correctly and never spawn duplicate-look cache entries.
+- `shapeAdapt:false` emits the **legacy** gradients (objectBoundingBox), byte-identical to ≤2.x, with an optional `rotate(angle 0.5 0.5)` for `angle`.
+
+### Lens field modes — FREE (`src/core/displacementMap.ts`)
+Each mode encodes a different displacement field into the R/B channels (R→x, B→y; displacement =
+`scale·(channel−0.5)`). All are static-SVG only (gradients, radialGradient, mask, mix-blend-mode,
+blur) — no new filter primitives, so they cost nothing at runtime. Derived + adversarially
+channel-math-verified before implementation (the convex sign and rim fold/monotonicity bugs were
+caught and corrected in that pass).
+- **classic** — the historical linear radial ramps (shape-adapted). Reads as a split/mirror at high `scale`.
+- **convex** — inward ramps (converging → magnify) windowed by a radial dome mask that fades the
+  field to neutral at the rim, so the pane reads as ONE coherent lens. Fold-safe: `CONVEX_AMP=0.3`,
+  reach `0.66·min(w,h)`.
+- **shift** — a uniform fill `rgb(0.5±off·cosθ, _, 0.5±off·sinθ)` soft-feathered to neutral at the
+  edge → rigid translation, fold-free interior. `angle` = direction.
+- **rim** — signed 3-stop ramps (anchored at neutral on the lens axis) confined by a soft radial
+  mask whose feather widens with strength; channels separated by `screen` over a black plate, over a
+  neutral plate. Clear flat center, refraction only at the perimeter band (`rimReach=0.4·min(w,h)`).
+- Fold guardrail: the lens amplitudes are capped so the field stays monotonic at the default `scale`
+  (≈160); cranking `lensStrength` × `scale` past the fold threshold can duplicate the image (documented).
+
+### Real animated refraction — GPU-REAL, gated (`src/core/liquid.ts` + React/WC wiring)
+- Adds an animated `feTurbulence` → `feDisplacementMap` stage to the **live inline Chromium filter** (same primitive the iOS/Safari mirror already uses). No per-frame data-URI regeneration.
+- Presets (pure param map in `liquid.ts`): **ripple** (fine isotropic boil), **flow** (anisotropic drift; direction follows `angle`), **wobble** (low-frequency, high-amplitude, slow).
+- A `requestAnimationFrame` driver updates the live turbulence node's `baseFrequency`/offset. **Gated:** runs only while visible (existing `IntersectionObserver`), paused on `prefers-reduced-motion`, Chromium-only, amplitude capped on mobile/low quality. Idle when `liquid` is unset.
+
+### Interaction (`src/interactive/index.tsx`)
+- `liquidTrigger: hover|press` ramps the displacement `scale` on the live filter via rAF easing (no cost when idle).
+- `followPointer`: a refractive bump element tracks the cursor (moved via compositor `transform`, eased), distorting the backdrop beneath it.
+
+## Components / data flow
+1. `src/core/displacementMap.ts` — `angle`, `shapeAdapt`, `normalizeAngle` (exported). [done first, TDD]
+2. `src/core/liquid.ts` (new) — preset → turbulence params + per-frame attribute helpers. Pure, tested.
+3. `src/index.tsx` — new props on the **interface (lines 25-62)** and the **inline `config` type (265-282)**; add the turbulence stage to the inline filter; rAF driver gated on visibility/reduced-motion; cache key `+= |ang:${normalizeAngle}|sa:${shapeAdapt}|lq:${liquid}`.
+4. `src/web-component/index.ts` — `angle`, `liquid`, `liquid-speed`, `liquid-scale`, `shape-adapt` attributes (+ `observedAttributes`); rAF driver.
+5. `src/interactive/index.tsx` — `liquidTrigger`, `followPointer`.
+6. Types — `src/index.d.ts` (hand-written; manual add) + `src/interactive/index.d.ts` (inherits via `extends LiquidGlassProps`) + web-component types.
+7. Tests — `displacementMap.test.ts` (faithful angle, isotropic amplitude, normalize, both gradients, square@0 ≈ legacy, `shapeAdapt:false` identical) + `liquid.test.ts`.
+8. Docs — README prop table, framework guides (vue/svelte/astro/vanilla), Storybook argTypes+args, examples landing.
+
+## Backward compatibility / versioning
+- **3.0.0.** Shape adaptation ON by default changes non-square visuals at `angle:0`. Square elements at `angle:0` are visually unchanged. `angle`/`liquid`/interaction are additive.
+- **Escape hatch:** `shapeAdapt={false}` → legacy map, byte-identical to 2.x.
+
+## Cost contract
+- **Free:** shape adaptation + `angle` (baked into the existing map; identical GPU graph).
+- **GPU-real, gated:** `liquid` presets + `followPointer`. `liquidTrigger: hover|press` cost nothing until interaction.
+
+## Caveats (folded from the prior review)
+- `angle` is exact only at 0° (identity) and 180° (negation); 90°/270° are a transpose; in-between is an artistic lean. Aspect adaptation makes the lean's *direction* faithful, not the displacement a pure vector rotation.
+- Liquid motion is the Chromium SVG-backdrop path only; fallback engines keep the (turbulence-based) mirror unchanged — optionally drive its motion in a later pass.
+- Non-cardinal angles can clamp box corners (pad spread); mitigated by the rotation living in aspect-true space and tuned visually.

--- a/docs/superpowers/specs/2026-06-17-refraction-angle-design.md
+++ b/docs/superpowers/specs/2026-06-17-refraction-angle-design.md
@@ -1,0 +1,128 @@
+# Refraction direction (`angle` prop) — design
+
+**Date:** 2026-06-17
+**Status:** approved (pending spec review)
+**Package:** `simple-liquid-glass` (v2.4.0 → next minor)
+
+## Problem
+
+The lens refracts the backdrop along a fixed geometry baked into the displacement
+map. There is no way to point the refraction in a chosen direction — e.g. for a
+navbar where a designer wants the light to lean a particular way. Today the only
+related knob is `scale` (negative inverts the bend), which is not a direction.
+
+## Goal
+
+Add a single, simple control that gives **freedom** (any direction) with a
+**simple value** (one number): `angle` in degrees. `angle: 0` reproduces the
+current look exactly. Other values rotate the refraction lean.
+
+Non-goals (explicitly out of scope for this change):
+
+- Keyword values (`'horizontal'` etc.) — numeric degrees only.
+- Mathematically pure vector rotation (see "Caveats").
+- Applying direction to the iOS/Safari mirror fallback (see "Caveats").
+
+## How refraction is produced today
+
+`buildDisplacementSvg` (`src/core/displacementMap.ts`) bakes two CSS linear
+gradients into an SVG used as the `feImage` of the refraction filter:
+
+- `red` gradient — **horizontal** ramp (`x1=100% … x2=0%`).
+- `blue` gradient — **vertical** ramp (`y1=0% … y2=100%`).
+
+The React component and web component both feed that map to
+`feDisplacementMap` with `xChannelSelector="R"`, `yChannelSelector="B"`
+(`src/index.tsx`, `src/web-component/index.ts`). So **Red drives horizontal
+displacement, Blue drives vertical displacement** — that mapping is fixed and is
+the constraint this feature works within.
+
+## Design
+
+### API
+
+A new optional prop / attribute:
+
+- React (`LiquidGlassProps`): `angle?: number` — degrees, default `0`.
+- Web component (`<liquid-glass>`): `angle` attribute (number), default `0`.
+- `LiquidGlassInteractive` inherits `LiquidGlassProps`, so it receives `angle`
+  with **no code change**.
+
+`angle: 0` (or omitted) must produce byte-for-byte identical output to today, so
+existing snapshots, caches, and visual behavior are unchanged.
+
+### Mechanism
+
+When `angle !== 0`, add `gradientTransform="rotate(${angle} 0.5 0.5)"` to **both**
+the `red` and `blue` `linearGradient` elements. Both gradients use
+`objectBoundingBox` units (percentage coords), so `0.5 0.5` is the box center.
+Rotating both by the same angle keeps them 90° apart in unit space, so the
+surface still reads as glass — the bright refraction crescents lean toward the
+chosen angle.
+
+When `angle === 0`, emit **no** `gradientTransform` attribute at all, guaranteeing
+identical output to the current implementation.
+
+The `feDisplacementMap` channel selectors stay `R`/`B`. Nothing in the filter
+graph changes; the rotation lives entirely in the baked map.
+
+### Components / data flow
+
+1. `src/core/displacementMap.ts`
+   - Add `angle?: number` to `DisplacementParams`.
+   - In `buildDisplacementSvg`, compute a transform attribute string
+     (`''` when angle is falsy/0, else `gradientTransform="rotate(${angle} 0.5 0.5)"`)
+     and apply it to both `linearGradient` tags.
+
+2. `src/index.tsx` (React)
+   - Add `angle = 0` to props + the `config` object.
+   - Pass `angle` to `buildDisplacementDataUri`.
+   - Add `angle` to the displacement memo **cache key** (so two lenses at
+     different angles never collide).
+
+3. `src/web-component/index.ts`
+   - Add `'angle'` to `observedAttributes`.
+   - Read `const angle = attrNum(this, 'angle', 0)` and pass to
+     `buildDisplacementDataUri`.
+
+4. `src/index.d.ts`
+   - Add the `angle` doc block + type to the hand-written declarations.
+
+### Testing
+
+Extend `src/__tests__/displacementMap.test.ts`:
+
+- `buildDisplacementSvg({ ...params, angle: 45 })` contains
+  `gradientTransform="rotate(45 0.5 0.5)"` (applied to both gradients).
+- `buildDisplacementSvg(params)` and `{ ...params, angle: 0 }` contain **no**
+  `gradientTransform` (backward-compat guarantee).
+- `buildDisplacementDataUri({ ...params, angle: 90 })` round-trips the transform
+  through URI encode/decode.
+
+Manual verification: a Storybook `angle` control (or the preview) to confirm the
+lean is visually correct on a wide navbar-shaped element across a few angles
+(0 / 45 / 90 / 180).
+
+## Caveats (documented, intentional)
+
+1. **Lean, not pure rotation.** Because `R`→x / `B`→y is rigid, rotating the
+   ramps rotates the *magnitude pattern*, not the displacement *vectors*. The
+   result is an exact rotation at 0/90/180/270° and an artistic lean in between.
+   This is the standard, cheap trick and reads well for a glass effect. A
+   mathematically pure rotation would require baking cos/sin mixing into the R/B
+   channels (more SVG math + GPU cost) and is deferred as a possible follow-up.
+
+2. **Aspect skew.** `objectBoundingBox` rotation happens in the normalized unit
+   square, then stretches to the element's aspect ratio. On a wide navbar a
+   "45°" is visually skewed by the aspect ratio. Consistent with the existing
+   approximation (the current map is already aspect-dependent) and acceptable for
+   a visual control.
+
+3. **Chromium path only.** `angle` affects the SVG-in-`backdrop-filter`
+   refraction (Chromium). The iOS/Safari/Firefox mirror fallback uses
+   `feTurbulence` noise, a different mechanism, and is unchanged.
+
+## Backward compatibility
+
+Fully additive. Default `angle: 0` emits no transform → identical output, caches,
+and snapshots. No existing prop changes.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "simple-liquid-glass",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "type": "module",
-  "description": "Zero-dependency React liquid glass with REAL refraction on iOS/Safari/Firefox (not just blur). SSR-safe, ~6.5KB, React 16.8–19. Web-component included.",
+  "description": "Zero-dependency React liquid glass with REAL refraction on iOS/Safari/Firefox (not just blur). Directional + animated 'liquid' refraction, lens modes. SSR-safe, ~10KB (web component ~5KB), React 16.8–19. Web-component included.",
   "main": "dist/index.cjs",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
@@ -46,19 +46,19 @@
     {
       "name": "core — import { LiquidGlass } (gzip, includes iOS mirror engine)",
       "path": "dist/index.esm.js",
-      "limit": "8.5 KB",
+      "limit": "10.5 KB",
       "ignore": ["react", "react-dom"]
     },
     {
       "name": "interactive — import { LiquidGlassInteractive } (gzip, bundles core)",
       "path": "dist/interactive.esm.js",
-      "limit": "9 KB",
+      "limit": "11.5 KB",
       "ignore": ["react", "react-dom"]
     },
     {
       "name": "mirror — import { LiquidGlassMirror } (gzip, bundles core)",
       "path": "dist/mirror.esm.js",
-      "limit": "9 KB",
+      "limit": "10.5 KB",
       "ignore": ["react", "react-dom"]
     },
     {

--- a/src/LiquidGlass.stories.tsx
+++ b/src/LiquidGlass.stories.tsx
@@ -76,6 +76,22 @@ const meta: Meta<LiquidGlassComponent> = {
     textOnDark: { control: 'color' },
     textOnLight: { control: 'color' },
     forceTextColor: { control: 'boolean' },
+    angle: { control: { type: 'range', min: 0, max: 360, step: 1 }, description: 'Refraction direction (deg). Shape-adapted: faithful on any aspect.' },
+    shapeAdapt: { control: 'boolean', description: 'Aspect-faithful + isotropic refraction (default on). Off = legacy map.' },
+    lens: {
+      control: 'select',
+      options: ['classic', 'convex', 'shift', 'rim'],
+      description: 'Lens field: classic radial / single convex dome / uniform shift / perimeter rim.',
+    },
+    lensStrength: { control: { type: 'range', min: 0, max: 2, step: 0.05 }, description: 'Manual magnitude of the lens field.' },
+    liquid: {
+      control: 'select',
+      options: ['off', 'ripple', 'flow', 'wobble'],
+      mapping: { off: false },
+      description: 'Real animated refraction preset (Chromium; pauses on reduced-motion / offscreen).',
+    },
+    liquidSpeed: { control: { type: 'range', min: 0.1, max: 4, step: 0.1 } },
+    liquidScale: { control: { type: 'range', min: 0, max: 60, step: 1 } },
   },
   args: {
     mode: 'preset',
@@ -100,6 +116,12 @@ const meta: Meta<LiquidGlassComponent> = {
     forceTextColor: false,
     iosMinBlur: 7,
     iosBlurMode: 'auto',
+    angle: 0,
+    shapeAdapt: true,
+    lens: 'classic',
+    lensStrength: 1,
+    liquid: 'off',
+    liquidSpeed: 1,
   },
 };
 

--- a/src/__tests__/displacementMap.test.ts
+++ b/src/__tests__/displacementMap.test.ts
@@ -1,4 +1,4 @@
-import { quantizedSize, buildDisplacementSvg, buildDisplacementDataUri } from '../core/displacementMap';
+import { quantizedSize, buildDisplacementSvg, buildDisplacementDataUri, normalizeAngle } from '../core/displacementMap';
 
 describe('quantizedSize', () => {
   it('quantizes to the step and floors at 8', () => {
@@ -8,8 +8,26 @@ describe('quantizedSize', () => {
   });
 });
 
+describe('normalizeAngle', () => {
+  it('wraps to [0,360), rounds, and coerces non-finite to 0', () => {
+    expect(normalizeAngle(0)).toBe(0);
+    expect(normalizeAngle(45)).toBe(45);
+    expect(normalizeAngle(360)).toBe(0);
+    expect(normalizeAngle(450)).toBe(90);
+    expect(normalizeAngle(-90)).toBe(270);
+    expect(normalizeAngle(45.00001)).toBe(45);
+    expect(normalizeAngle(NaN)).toBe(0);
+    expect(normalizeAngle(Infinity)).toBe(0);
+    expect(normalizeAngle(undefined)).toBe(0);
+  });
+});
+
 describe('buildDisplacementSvg', () => {
+  // 400x200 @ divisor 5 / step 32 -> 96x32 (a wide 3:1 element)
   const params = { width: 400, height: 200, divisor: 5, quantStep: 32, radius: 50, border: 0.05, lightness: 53, alpha: 0.9, displace: 5 };
+  // 320x320 -> 64x64 (square)
+  const square = { width: 320, height: 320, divisor: 5, quantStep: 32, radius: 50, border: 0.05, lightness: 53, alpha: 0.9, displace: 5 };
+  const countTransforms = (svg: string) => (svg.match(/gradientTransform/g) || []).length;
 
   it('embeds the quantized viewBox and the shape params', () => {
     const svg = buildDisplacementSvg(params);
@@ -22,12 +40,137 @@ describe('buildDisplacementSvg', () => {
   it('honors a custom blend mode', () => {
     expect(buildDisplacementSvg({ ...params, blend: 'screen' })).toContain('mix-blend-mode: screen');
   });
+
+  describe('shape adaptation (default on)', () => {
+    it('builds aspect-true gradients in userSpaceOnUse', () => {
+      const svg = buildDisplacementSvg(params);
+      expect(svg).toContain('gradientUnits="userSpaceOnUse"');
+    });
+
+    it('makes refraction isotropic by scaling the short-axis amplitude', () => {
+      // 96x32: long axis (width) keeps full amplitude, short axis (height) scaled by 32/96.
+      const svg = buildDisplacementSvg(params);
+      expect(svg).toContain('rgb(255,0,0)'); // red (horizontal) full
+      expect(svg).toContain('rgb(0,0,85)'); // blue (vertical) reduced ~= 255*32/96
+    });
+
+    it('leaves both amplitudes full on a square element', () => {
+      const svg = buildDisplacementSvg(square);
+      expect(svg).toContain('rgb(255,0,0)');
+      expect(svg).toContain('rgb(0,0,255)');
+    });
+  });
+
+  describe('angle (faithful, shape-adapted)', () => {
+    it('rotates BOTH gradients about the pixel center', () => {
+      const svg = buildDisplacementSvg({ ...params, angle: 45 });
+      // center of a 96x32 viewBox
+      expect(svg).toContain('gradientTransform="rotate(45 48 16)"');
+      expect(countTransforms(svg)).toBe(2);
+    });
+
+    it('emits NO gradientTransform at angle 0 or omitted (and at 360)', () => {
+      expect(countTransforms(buildDisplacementSvg(params))).toBe(0);
+      expect(countTransforms(buildDisplacementSvg({ ...params, angle: 0 }))).toBe(0);
+      expect(countTransforms(buildDisplacementSvg({ ...params, angle: 360 }))).toBe(0);
+    });
+  });
+
+  describe('shapeAdapt:false (legacy escape hatch)', () => {
+    it('emits the legacy objectBoundingBox gradients', () => {
+      const svg = buildDisplacementSvg({ ...params, shapeAdapt: false });
+      expect(svg).toContain('<linearGradient id="red" x1="100%" y1="0%" x2="0%" y2="0%">');
+      expect(svg).toContain('stop-color="red"');
+      expect(svg).not.toContain('userSpaceOnUse');
+    });
+
+    it('is byte-identical at angle 0 to having no angle', () => {
+      expect(buildDisplacementSvg({ ...params, shapeAdapt: false })).toBe(
+        buildDisplacementSvg({ ...params, shapeAdapt: false, angle: 0 })
+      );
+    });
+
+    it('rotates in unit space when an angle is given', () => {
+      const svg = buildDisplacementSvg({ ...params, shapeAdapt: false, angle: 45 });
+      expect(svg).toContain('gradientTransform="rotate(45 0.5 0.5)"');
+      expect(countTransforms(svg)).toBe(2);
+    });
+  });
+});
+
+describe('lens modes', () => {
+  const base = { width: 320, height: 320, divisor: 5, quantStep: 32, radius: 50, border: 0.05, lightness: 53, alpha: 0.9, displace: 5 };
+
+  it('defaults to classic (linear ramps) and is unaffected by lens props when classic', () => {
+    const svg = buildDisplacementSvg(base);
+    expect(svg).toContain('linearGradient id="red"');
+    expect(svg).not.toContain('cvxMask');
+    expect(svg).not.toContain('shiftMask');
+    expect(svg).not.toContain('rimMask');
+  });
+
+  describe('convex', () => {
+    const p = { ...base, lens: 'convex' as const };
+    it('builds a radial dome mask + two channel baselines', () => {
+      const svg = buildDisplacementSvg(p);
+      expect(svg).toContain('radialGradient id="cvxEnv"');
+      expect(svg).toContain('mask id="cvxMask"');
+      expect(svg).toContain('fill="rgb(128,0,0)"');
+      expect(svg).toContain('fill="rgb(0,0,128)"');
+      expect(svg).toContain('mask="url(#cvxMask)"');
+    });
+    it('collapses to a neutral no-op ramp at strength 0', () => {
+      const svg = buildDisplacementSvg({ ...p, lensStrength: 0 });
+      expect(svg).toContain('<linearGradient id="cvxRed"><stop offset="0%" stop-color="rgb(128,0,0)"/></linearGradient>');
+    });
+  });
+
+  describe('shift', () => {
+    const p = { ...base, lens: 'shift' as const };
+    it('encodes the direction analytically into a uniform fill (no blend mode)', () => {
+      const svg = buildDisplacementSvg({ ...p, lensStrength: 1, angle: 0 });
+      expect(svg).toContain('mask="url(#shiftMask)"');
+      expect(svg).toContain('fill="rgb(191,0,128)"'); // 0.5 + 0.25 on R, neutral B
+      expect(svg).not.toContain('mix-blend-mode');
+    });
+    it('points the offset along the vertical axis at angle 90', () => {
+      expect(buildDisplacementSvg({ ...p, lensStrength: 1, angle: 90 })).toContain('fill="rgb(128,0,191)"');
+    });
+    it('is a uniform neutral field at strength 0', () => {
+      const svg = buildDisplacementSvg({ ...p, lensStrength: 0 });
+      expect((svg.match(/rgb\(128,0,128\)/g) || []).length).toBe(2);
+    });
+  });
+
+  describe('rim', () => {
+    const p = { ...base, lens: 'rim' as const };
+    it('builds a radial confinement mask + screen-separated signed ramps over a neutral plate', () => {
+      const svg = buildDisplacementSvg(p);
+      expect(svg).toContain('radialGradient id="rimRadial"');
+      expect(svg).toContain('mask id="rimMask"');
+      expect(svg).toContain('linearGradient id="rimRed"');
+      expect(svg).toContain('mix-blend-mode: screen');
+      expect(svg).toContain('fill="rgb(128,0,128)"'); // flat neutral center plate
+    });
+    it('omits the classic blurred border band (rim owns its own edge)', () => {
+      // the gray hsl band is present for classic/convex/shift but not rim
+      expect(buildDisplacementSvg(p)).not.toContain('hsl(0 0% 53% / 0.9)');
+      expect(buildDisplacementSvg({ ...base, lens: 'convex' })).toContain('hsl(0 0% 53% / 0.9)');
+    });
+  });
 });
 
 describe('buildDisplacementDataUri', () => {
+  const params = { width: 400, height: 200, divisor: 5, quantStep: 32, radius: 50, border: 0.05, lightness: 53, alpha: 0.9, displace: 5 };
+
   it('produces an encoded svg data URI', () => {
-    const uri = buildDisplacementDataUri({ width: 400, height: 200, divisor: 5, quantStep: 32, radius: 50, border: 0.05, lightness: 53, alpha: 0.9, displace: 5 });
+    const uri = buildDisplacementDataUri(params);
     expect(uri.startsWith('data:image/svg+xml,')).toBe(true);
     expect(decodeURIComponent(uri)).toContain('viewBox="0 0 96 32"');
+  });
+
+  it('round-trips the angle transform through encode/decode', () => {
+    const uri = buildDisplacementDataUri({ ...params, angle: 90 });
+    expect(decodeURIComponent(uri)).toContain('gradientTransform="rotate(90 48 16)"');
   });
 });

--- a/src/__tests__/liquid.test.ts
+++ b/src/__tests__/liquid.test.ts
@@ -1,0 +1,71 @@
+import { liquidConfig, liquidBaseFrequency, isLiquidPreset, LIQUID_PRESETS } from '../core/liquid';
+
+describe('liquid presets', () => {
+  it('exposes the three presets and a type guard', () => {
+    expect(LIQUID_PRESETS).toEqual(['ripple', 'flow', 'wobble']);
+    expect(isLiquidPreset('ripple')).toBe(true);
+    expect(isLiquidPreset('wobble')).toBe(true);
+    expect(isLiquidPreset('nope')).toBe(false);
+    expect(isLiquidPreset(undefined)).toBe(false);
+  });
+
+  describe('liquidConfig', () => {
+    it('returns the preset defaults', () => {
+      const c = liquidConfig('ripple');
+      expect(c.scale).toBe(15);
+      expect(c.numOctaves).toBe(2);
+      expect(c.seed).toBe(3);
+    });
+
+    it('honors a scale override', () => {
+      expect(liquidConfig('ripple', { scale: 40 }).scale).toBe(40);
+    });
+
+    it('caps amplitude with maxScale', () => {
+      expect(liquidConfig('wobble', { maxScale: 10 }).scale).toBe(10);
+      // a cap above the preset is a no-op
+      expect(liquidConfig('ripple', { maxScale: 100 }).scale).toBe(15);
+    });
+
+    it('never returns a negative scale', () => {
+      expect(liquidConfig('ripple', { scale: -5 }).scale).toBe(0);
+    });
+
+    it('falls back to ripple for an unknown preset', () => {
+      // @ts-expect-error exercising the runtime guard
+      expect(liquidConfig('bogus').scale).toBe(15);
+    });
+  });
+
+  describe('liquidBaseFrequency', () => {
+    it('stays within the preset oscillation band for all t', () => {
+      // ripple base 0.012 ± 0.004 on both axes
+      for (let t = 0; t < 20; t += 0.37) {
+        const [x, y] = liquidBaseFrequency('ripple', t);
+        expect(x).toBeGreaterThanOrEqual(0.008 - 1e-9);
+        expect(x).toBeLessThanOrEqual(0.016 + 1e-9);
+        expect(y).toBeGreaterThanOrEqual(0.008 - 1e-9);
+        expect(y).toBeLessThanOrEqual(0.016 + 1e-9);
+      }
+    });
+
+    it('keeps the flow y-frequency constant (anisotropic drift)', () => {
+      const [, y0] = liquidBaseFrequency('flow', 0);
+      const [, y1] = liquidBaseFrequency('flow', 5);
+      expect(y0).toBe(0.016);
+      expect(y1).toBe(0.016);
+    });
+
+    it('scales motion with speed', () => {
+      const slow = liquidBaseFrequency('ripple', 1, 0.5);
+      const fast = liquidBaseFrequency('ripple', 1, 4);
+      expect(slow).not.toEqual(fast);
+    });
+
+    it('coerces non-finite t/speed to a stable value', () => {
+      const [x, y] = liquidBaseFrequency('ripple', NaN, Infinity);
+      expect(Number.isFinite(x)).toBe(true);
+      expect(Number.isFinite(y)).toBe(true);
+    });
+  });
+});

--- a/src/core/displacementMap.ts
+++ b/src/core/displacementMap.ts
@@ -4,6 +4,15 @@
  * as the feImage in the refraction filter. No DOM, no React.
  */
 
+/**
+ * Lens field shape:
+ * - `classic` — linear radial field (the historical look; reads as a split/mirror at high scale).
+ * - `convex`  — one coherent dome magnifier (a radial field windowed to neutral at the rim).
+ * - `shift`   — a uniform directional offset (whole pane slides one way; straight stays straight).
+ * - `rim`     — flat clear center, refraction only in a soft band hugging the perimeter.
+ */
+export type LensMode = 'classic' | 'convex' | 'shift' | 'rim';
+
 export interface DisplacementParams {
   width: number;
   height: number;
@@ -17,6 +26,23 @@ export interface DisplacementParams {
   alpha: number;
   displace: number;
   blend?: string;
+  /**
+   * Refraction direction in degrees. `0` = baseline (current look). Positive rotates the lean
+   * clockwise on screen (SVG y-down). For `lens: 'shift'`, this is the direction of the offset.
+   */
+  angle?: number;
+  /**
+   * Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's
+   * shape. `true` (default, 3.0.0) builds the map in aspect-true pixel space. `false` emits the
+   * legacy (≤2.x) objectBoundingBox map, byte-for-byte unchanged. Applies to `lens: 'classic'`.
+   */
+  shapeAdapt?: boolean;
+  /** Lens field shape (default `'classic'`). */
+  lens?: LensMode;
+  /** Manual magnitude for the lens field (default 1). 0 = no lens displacement. */
+  lensStrength?: number;
+  /** Lens center for `convex`/`rim`, normalized 0..1 (default `[0.5, 0.5]`). */
+  lensCenter?: [number, number];
 }
 
 /** Quantized internal map dimensions for a given rendered size + quality. */
@@ -26,24 +52,216 @@ export function quantizedSize(width: number, height: number, divisor: number, qu
   return { newwidth, newheight };
 }
 
+/**
+ * Canonicalize an angle: non-finite → 0, wrapped to [0, 360), rounded to 3 decimals. Used for
+ * both the emitted SVG and the cache key so `360`, `NaN`, `Infinity`, and float noise like
+ * `45.0000001` collapse to a single stable value (and `0`/`360` to the no-transform fast path).
+ */
+export function normalizeAngle(angle?: number): number {
+  const a = typeof angle === 'number' && Number.isFinite(angle) ? angle : 0;
+  const wrapped = ((a % 360) + 360) % 360;
+  return Math.round(wrapped * 1000) / 1000;
+}
+
+/** Legacy (≤2.x) gradients in objectBoundingBox units. `angle` rotates both about the box center. */
+function legacyGradients(angle: number): string {
+  const gt = angle !== 0 ? ` gradientTransform="rotate(${angle} 0.5 0.5)"` : '';
+  return `          <linearGradient id="red" x1="100%" y1="0%" x2="0%" y2="0%"${gt}>
+            <stop offset="0%" stop-color="#0000"/>
+            <stop offset="100%" stop-color="red"/>
+          </linearGradient>
+          <linearGradient id="blue" x1="0%" y1="0%" x2="0%" y2="100%"${gt}>
+            <stop offset="0%" stop-color="#0000"/>
+            <stop offset="100%" stop-color="blue"/>
+          </linearGradient>`;
+}
+
+/**
+ * Shape-adapted gradients in aspect-true pixel space (userSpaceOnUse over the viewBox).
+ * - Faithful angle: rotate about the pixel center, so an on-screen angle is preserved on any aspect.
+ * - Isotropic refraction: scale each ramp's amplitude so the per-pixel displacement slope matches
+ *   on both axes (long axis = full amplitude, short axis scaled by shortExtent/longestExtent),
+ *   removing the over-bending on the short axis of a wide/tall element. On a square this is identical
+ *   to the legacy ramps (both amplitudes = full).
+ */
+function adaptedGradients(newwidth: number, newheight: number, angle: number): string {
+  const cx = newwidth / 2;
+  const cy = newheight / 2;
+  const longest = Math.max(newwidth, newheight);
+  const redAmp = Math.round((255 * newwidth) / longest); // horizontal ramp amplitude
+  const blueAmp = Math.round((255 * newheight) / longest); // vertical ramp amplitude
+  const gt = angle !== 0 ? ` gradientTransform="rotate(${angle} ${cx} ${cy})"` : '';
+  return `          <linearGradient id="red" gradientUnits="userSpaceOnUse" x1="${newwidth}" y1="${cy}" x2="0" y2="${cy}"${gt}>
+            <stop offset="0%" stop-color="#0000"/>
+            <stop offset="100%" stop-color="rgb(${redAmp},0,0)"/>
+          </linearGradient>
+          <linearGradient id="blue" gradientUnits="userSpaceOnUse" x1="${cx}" y1="0" x2="${cx}" y2="${newheight}"${gt}>
+            <stop offset="0%" stop-color="#0000"/>
+            <stop offset="100%" stop-color="rgb(0,0,${blueAmp})"/>
+          </linearGradient>`;
+}
+
+interface LensInner {
+  defs: string;
+  body: string;
+}
+
+// Tunable amplitude budgets (kept conservative so the default scale stays fold-free; see the
+// fold analysis in the design spec). lensStrength scales these; the channel deviation is capped
+// at 0.5 (the encodable maximum).
+const CONVEX_AMP = 0.3; // peak channel deviation at strength 1
+const CONVEX_REACH = 0.66; // dome radius as a fraction of the short side
+const RIM_AMP = 0.42; // peak rim channel deviation at strength 1 (× 127 bytes)
+const SHIFT_GAIN = 0.5; // half the channel swing at strength 1
+
+/**
+ * `convex` — one coherent radial magnifier centered at the lens. Two channel groups carry R and B
+ * independently (red source-over a 0.5 baseline, blue via difference), each an INWARD ramp (R high
+ * toward the center side → converging → magnify), windowed by a radial dome mask that fades the
+ * field to neutral at the rim so the pane reads as a single lens instead of a split.
+ */
+function buildConvexInner(
+  w: number,
+  h: number,
+  er: number,
+  angle: number,
+  strength: number,
+  lcx: number,
+  lcy: number
+): LensInner {
+  const Lx = lcx * w;
+  const Ly = lcy * h;
+  const Rlens = Math.max(8, Math.min(w, h) * CONVEX_REACH);
+  const dev = strength > 0 ? Math.min(0.5, CONVEX_AMP * strength) : 0;
+  const hi = Math.round((0.5 + dev) * 255);
+  const lo = Math.round((0.5 - dev) * 255);
+  const gt = angle !== 0 ? ` gradientTransform="rotate(${angle} ${Lx} ${Ly})"` : '';
+  const redRamp =
+    dev > 0
+      ? `<linearGradient id="cvxRed" gradientUnits="userSpaceOnUse" x1="${Lx - Rlens}" y1="${Ly}" x2="${Lx + Rlens}" y2="${Ly}"${gt}><stop offset="0%" stop-color="rgb(${hi},0,0)"/><stop offset="100%" stop-color="rgb(${lo},0,0)"/></linearGradient>`
+      : `<linearGradient id="cvxRed"><stop offset="0%" stop-color="rgb(128,0,0)"/></linearGradient>`;
+  const blueRamp =
+    dev > 0
+      ? `<linearGradient id="cvxBlue" gradientUnits="userSpaceOnUse" x1="${Lx}" y1="${Ly - Rlens}" x2="${Lx}" y2="${Ly + Rlens}"${gt}><stop offset="0%" stop-color="rgb(0,0,${hi})"/><stop offset="100%" stop-color="rgb(0,0,${lo})"/></linearGradient>`
+      : `<linearGradient id="cvxBlue"><stop offset="0%" stop-color="rgb(0,0,128)"/></linearGradient>`;
+  const defs = `${redRamp}
+          ${blueRamp}
+          <radialGradient id="cvxEnv" gradientUnits="userSpaceOnUse" cx="${Lx}" cy="${Ly}" r="${Rlens}" fx="${Lx}" fy="${Ly}"><stop offset="0%" stop-color="#fff"/><stop offset="40%" stop-color="#fff"/><stop offset="100%" stop-color="#000"/></radialGradient>
+          <mask id="cvxMask" maskUnits="userSpaceOnUse" x="0" y="0" width="${w}" height="${h}"><rect x="0" y="0" width="${w}" height="${h}" fill="url(#cvxEnv)"/></mask>`;
+  const body = `<rect x="0" y="0" width="${w}" height="${h}" fill="black"/>
+        <g>
+          <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="rgb(128,0,0)"/>
+          <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="url(#cvxRed)" mask="url(#cvxMask)"/>
+        </g>
+        <g style="mix-blend-mode: difference">
+          <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="rgb(0,0,128)"/>
+          <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="url(#cvxBlue)" mask="url(#cvxMask)"/>
+        </g>`;
+  return { defs, body };
+}
+
+/**
+ * `shift` — a uniform directional refraction. R and B are flat constants (0.5 ± offset) across the
+ * whole pane, soft-feathered to neutral at the edge, so the displacement is a rigid translation:
+ * straight backdrop lines stay straight, just offset. `angle` is the offset direction. Fold-free in
+ * the interior (constant field). No blend mode needed.
+ */
+function buildShiftInner(w: number, h: number, bw: number, er: number, angle: number, strength: number): LensInner {
+  const rad = (angle * Math.PI) / 180;
+  const off = Math.max(0, Math.min(0.5, 0.5 * SHIFT_GAIN * strength));
+  const rByte = Math.round((0.5 + off * Math.cos(rad)) * 255); // RED → horizontal
+  const bByte = Math.round((0.5 + off * Math.sin(rad)) * 255); // BLUE → vertical
+  // Cap the feather to ~1/3 of the half-extent so a full-alpha interior plateau always exists
+  // (otherwise thin maps collapse the white rect to a sub-blur strip and the field is too weak).
+  const halfMin = Math.min(w, h) / 2 - 0.5;
+  const feather = Math.max(1, Math.min(bw, halfMin / 3));
+  const defs = `<mask id="shiftMask" maskUnits="userSpaceOnUse" x="0" y="0" width="${w}" height="${h}"><rect x="0" y="0" width="${w}" height="${h}" fill="black"/><rect x="${feather}" y="${feather}" width="${w - feather * 2}" height="${h - feather * 2}" rx="${Math.max(0, er - feather)}" fill="white" style="filter:blur(${feather}px)"/></mask>`;
+  const body = `<rect x="0" y="0" width="${w}" height="${h}" fill="rgb(128,0,128)"/>
+        <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="rgb(${rByte},0,${bByte})" mask="url(#shiftMask)"/>`;
+  return { defs, body };
+}
+
+/**
+ * `rim` — flat clear center, refraction only in a band hugging the perimeter. A signed 3-stop ramp
+ * per channel (anchored at neutral 0.5 on the lens axis) is confined by a soft radial mask whose
+ * feather WIDENS with strength (so more strength is gentler, not steeper). Channels are separated
+ * with `screen` over a black plate so both survive without corrupting the 0.5 baseline.
+ */
+function buildRimInner(
+  w: number,
+  h: number,
+  bw: number,
+  er: number,
+  angle: number,
+  strength: number,
+  lcx: number,
+  lcy: number
+): LensInner {
+  const Lx = lcx * w;
+  const Ly = lcy * h;
+  const amp = Math.min(1, Math.max(0, strength));
+  const d = Math.round(127 * RIM_AMP * amp);
+  const hi = Math.min(255, 128 + d);
+  const lo = Math.max(0, 128 - d);
+  const outerR = Math.min(w, h) / 2;
+  // Band width is a visible fraction of the half-extent (not the tiny CSS border), widening with
+  // strength so more strength = gentler edge (fold-safe), per the verified design.
+  const rimReach = Math.max(bw * 1.6, Math.min(w, h) * 0.4);
+  const innerR = Math.max(0, outerR - rimReach * amp);
+  const innerPct = ((100 * innerR) / outerR).toFixed(2);
+  const gt = angle !== 0 ? ` gradientTransform="rotate(${angle} ${Lx} ${Ly})"` : '';
+  const defs = `<linearGradient id="rimRed" gradientUnits="userSpaceOnUse" x1="0" y1="${Ly}" x2="${w}" y2="${Ly}"${gt}><stop offset="0%" stop-color="rgb(${lo},0,0)"/><stop offset="50%" stop-color="rgb(128,0,0)"/><stop offset="100%" stop-color="rgb(${hi},0,0)"/></linearGradient>
+          <linearGradient id="rimBlue" gradientUnits="userSpaceOnUse" x1="${Lx}" y1="0" x2="${Lx}" y2="${h}"${gt}><stop offset="0%" stop-color="rgb(0,0,${lo})"/><stop offset="50%" stop-color="rgb(0,0,128)"/><stop offset="100%" stop-color="rgb(0,0,${hi})"/></linearGradient>
+          <radialGradient id="rimRadial" gradientUnits="userSpaceOnUse" cx="${Lx}" cy="${Ly}" r="${outerR}"${gt}><stop offset="0%" stop-color="#000"/><stop offset="${innerPct}%" stop-color="#000"/><stop offset="100%" stop-color="#fff"/></radialGradient>
+          <mask id="rimMask" maskUnits="userSpaceOnUse" x="0" y="0" width="${w}" height="${h}"><rect x="0" y="0" width="${w}" height="${h}" fill="url(#rimRadial)"/></mask>`;
+  const body = `<rect x="0" y="0" width="${w}" height="${h}" fill="rgb(128,0,128)"/>
+        <g mask="url(#rimMask)">
+          <rect x="0" y="0" width="${w}" height="${h}" fill="black"/>
+          <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="url(#rimRed)"/>
+          <rect x="0" y="0" width="${w}" height="${h}" rx="${er}" fill="url(#rimBlue)" style="mix-blend-mode: screen"/>
+        </g>`;
+  return { defs, body };
+}
+
 export function buildDisplacementSvg(p: DisplacementParams): string {
   const { width, height, divisor, quantStep, radius, border, lightness, alpha, displace } = p;
   const blend = p.blend ?? 'difference';
+  const angle = normalizeAngle(p.angle);
+  const shapeAdapt = p.shapeAdapt !== false;
+  const lens: LensMode = p.lens ?? 'classic';
+  const strength = typeof p.lensStrength === 'number' && Number.isFinite(p.lensStrength) ? Math.max(0, p.lensStrength) : 1;
+  const lcx = p.lensCenter ? p.lensCenter[0] : 0.5;
+  const lcy = p.lensCenter ? p.lensCenter[1] : 0.5;
   const { newwidth, newheight } = quantizedSize(width, height, divisor, quantStep);
   const borderWidth = Math.min(newwidth, newheight) * (border * 0.5);
   const effectiveRadius = Math.min(radius, width / 2, height / 2) / divisor;
 
+  if (lens !== 'classic') {
+    const band = `<rect x="${borderWidth}" y="${borderWidth}" width="${newwidth - borderWidth * 2}" height="${newheight - borderWidth * 2}" rx="${effectiveRadius}" fill="hsl(0 0% ${lightness}% / ${alpha})" style="filter:blur(${displace}px)" />`;
+    let inner: LensInner;
+    if (lens === 'convex') inner = buildConvexInner(newwidth, newheight, effectiveRadius, angle, strength, lcx, lcy);
+    else if (lens === 'shift') inner = buildShiftInner(newwidth, newheight, borderWidth, effectiveRadius, angle, strength);
+    else inner = buildRimInner(newwidth, newheight, borderWidth, effectiveRadius, angle, strength, lcx, lcy);
+    // The blurred neutral band is the glass-edge highlight for convex/shift; `rim` owns its own
+    // edge, so adding the band there would overwrite the rim field.
+    const body = lens === 'rim' ? inner.body : `${inner.body}
+        ${band}`;
+    return `
+      <svg viewBox="0 0 ${newwidth} ${newheight}" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          ${inner.defs}
+        </defs>
+        ${body}
+      </svg>
+    `;
+  }
+
+  const defs = shapeAdapt ? adaptedGradients(newwidth, newheight, angle) : legacyGradients(angle);
+
   return `
       <svg viewBox="0 0 ${newwidth} ${newheight}" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <linearGradient id="red" x1="100%" y1="0%" x2="0%" y2="0%">
-            <stop offset="0%" stop-color="#0000"/>
-            <stop offset="100%" stop-color="red"/>
-          </linearGradient>
-          <linearGradient id="blue" x1="0%" y1="0%" x2="0%" y2="100%">
-            <stop offset="0%" stop-color="#0000"/>
-            <stop offset="100%" stop-color="blue"/>
-          </linearGradient>
+${defs}
         </defs>
         <rect x="0" y="0" width="${newwidth}" height="${newheight}" fill="black"/>
         <rect x="0" y="0" width="${newwidth}" height="${newheight}" rx="${effectiveRadius}" fill="url(#red)" />

--- a/src/core/liquid.ts
+++ b/src/core/liquid.ts
@@ -1,0 +1,74 @@
+/**
+ * Liquid motion presets for the real animated refraction. Pure: maps a preset name + options to
+ * the static `feTurbulence`/`feDisplacementMap` config and the per-frame `baseFrequency` values.
+ * No DOM, no rAF — the React/web-component layer owns the loop and just calls these. Keeping the
+ * math here makes it unit-testable and identical across both renderers.
+ */
+
+export type LiquidPreset = 'ripple' | 'flow' | 'wobble';
+
+export const LIQUID_PRESETS: readonly LiquidPreset[] = ['ripple', 'flow', 'wobble'];
+
+export function isLiquidPreset(v: unknown): v is LiquidPreset {
+  return typeof v === 'string' && (LIQUID_PRESETS as readonly string[]).includes(v);
+}
+
+/** Static turbulence/displacement config (the values that don't change per frame). */
+export interface LiquidConfig {
+  baseFrequencyX: number;
+  baseFrequencyY: number;
+  numOctaves: number;
+  /** Displacement amplitude in px (feeds feDisplacementMap@scale). */
+  scale: number;
+  seed: number;
+}
+
+export interface LiquidOptions {
+  /** Motion rate multiplier (default 1). */
+  speed?: number;
+  /** Override the preset's displacement amplitude. */
+  scale?: number;
+  /** Hard cap on amplitude (mobile / low quality). */
+  maxScale?: number;
+}
+
+interface PresetSpec extends LiquidConfig {
+  /** baseFrequency oscillation amplitude per axis. */
+  ampX: number;
+  ampY: number;
+  /** oscillation rate per axis (rad/s at speed 1). */
+  rateX: number;
+  rateY: number;
+}
+
+const PRESETS: Record<LiquidPreset, PresetSpec> = {
+  // fine, isotropic water-surface boil
+  ripple: { baseFrequencyX: 0.012, baseFrequencyY: 0.012, numOctaves: 2, scale: 15, seed: 3, ampX: 0.004, ampY: 0.004, rateX: 1.3, rateY: 1.1 },
+  // anisotropic drift — the distortion streams across one axis
+  flow: { baseFrequencyX: 0.01, baseFrequencyY: 0.016, numOctaves: 2, scale: 18, seed: 7, ampX: 0.006, ampY: 0, rateX: 0.7, rateY: 0 },
+  // slow, low-frequency, high-amplitude gel wobble
+  wobble: { baseFrequencyX: 0.006, baseFrequencyY: 0.006, numOctaves: 1, scale: 28, seed: 11, ampX: 0.0022, ampY: 0.0022, rateX: 0.55, rateY: 0.5 },
+};
+
+const round4 = (n: number) => Math.round(n * 10000) / 10000;
+
+/** Resolve the static config for a preset, applying scale override / cap. */
+export function liquidConfig(preset: LiquidPreset, opts: LiquidOptions = {}): LiquidConfig {
+  const p = PRESETS[preset] ?? PRESETS.ripple;
+  let scale = opts.scale != null && Number.isFinite(opts.scale) ? opts.scale : p.scale;
+  if (opts.maxScale != null && Number.isFinite(opts.maxScale)) scale = Math.min(scale, opts.maxScale);
+  scale = Math.max(0, scale);
+  return { baseFrequencyX: p.baseFrequencyX, baseFrequencyY: p.baseFrequencyY, numOctaves: p.numOctaves, scale, seed: p.seed };
+}
+
+/**
+ * Per-frame `baseFrequency` for the live turbulence node, given elapsed seconds. The value always
+ * stays within `[base - amp, base + amp]` of the preset so the noise never collapses or explodes.
+ */
+export function liquidBaseFrequency(preset: LiquidPreset, tSeconds: number, speed = 1): [number, number] {
+  const p = PRESETS[preset] ?? PRESETS.ripple;
+  const s = (Number.isFinite(tSeconds) ? tSeconds : 0) * (Number.isFinite(speed) ? speed : 1);
+  const x = p.baseFrequencyX + p.ampX * Math.sin(s * p.rateX);
+  const y = p.ampY ? p.baseFrequencyY + p.ampY * Math.cos(s * p.rateY) : p.baseFrequencyY;
+  return [round4(Math.max(0.0001, x)), round4(Math.max(0.0001, y))];
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,11 @@
 import { ReactNode, CSSProperties, HTMLAttributes, ForwardRefExoticComponent, RefAttributes } from 'react';
 
+/** Real animated refraction presets. */
+export type LiquidPreset = 'ripple' | 'flow' | 'wobble';
+
+/** Lens field shape. */
+export type LensMode = 'classic' | 'convex' | 'shift' | 'rim';
+
 export interface LiquidGlassProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The content to be displayed inside the liquid glass effect
@@ -181,6 +187,52 @@ export interface LiquidGlassProps extends HTMLAttributes<HTMLDivElement> {
    * @default false
    */
   autodetectquality?: boolean;
+
+  /**
+   * Refraction direction, in degrees. In-plane rotation of the lean (not a 3D light-incidence
+   * tilt). `0` is the baseline/current look; positive rotates the lean clockwise on screen.
+   * Shape-adapted, so the on-screen angle is faithful on any aspect ratio. Chromium SVG path only.
+   * @default 0
+   */
+  angle?: number;
+  /**
+   * Aspect-faithful + isotropic refraction so the lens reads like glass cut to the element's
+   * shape (a long navbar / tall sidebar refracts evenly). `false` restores the legacy ≤2.x map.
+   * @default true
+   */
+  shapeAdapt?: boolean;
+  /**
+   * Lens field shape. `'classic'` (default) is the linear radial field; `'convex'` is one coherent
+   * dome magnifier; `'shift'` is a uniform directional offset (straight stays straight); `'rim'`
+   * leaves the center clear and refracts only at a soft perimeter band.
+   * @default 'classic'
+   */
+  lens?: LensMode;
+  /**
+   * Manual magnitude for the lens field. `0` disables the lens displacement.
+   * @default 1
+   */
+  lensStrength?: number;
+  /**
+   * Lens center for `convex` / `rim`, normalized `0..1`.
+   * @default [0.5, 0.5]
+   */
+  lensCenter?: [number, number];
+  /**
+   * Real animated refraction — the backdrop genuinely warps. Opt-in, GPU-real: runs only while
+   * on-screen, pauses on `prefers-reduced-motion`, Chromium SVG path only. `false` disables it.
+   * @default false
+   */
+  liquid?: LiquidPreset | false;
+  /**
+   * Motion rate multiplier for `liquid`.
+   * @default 1
+   */
+  liquidSpeed?: number;
+  /**
+   * Distortion amplitude (px) for `liquid`. Defaults to the preset's amplitude.
+   */
+  liquidScale?: number;
 }
 
 /** Imperative handle exposed via ref. */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,10 @@
 import React, { useMemo, useEffect, useRef, useState, useId, forwardRef, useImperativeHandle } from 'react';
 import { parseCssColorToRgba, findNearestOpaqueBackground, isRgbColorDark } from './cssColor';
 import { cacheGet, cacheSet } from './displacementCache';
-import { quantizedSize, buildDisplacementDataUri } from './core/displacementMap';
+import { quantizedSize, buildDisplacementDataUri, normalizeAngle } from './core/displacementMap';
+import type { LensMode } from './core/displacementMap';
+import { liquidConfig, liquidBaseFrequency, isLiquidPreset } from './core/liquid';
+import type { LiquidPreset } from './core/liquid';
 import { useMirrorEngine } from './core/mirrorEngine';
 import { decisiveTier, classifyQuality } from './quality';
 import type { LiquidQuality } from './quality';
@@ -59,6 +62,17 @@ export interface LiquidGlassProps extends React.HTMLAttributes<HTMLDivElement> {
   backdropSelector?: string; // alternative to backdropRef: a CSS selector resolved on mount
   mirrorScale?: number; // mirror displacement strength (default 26)
   track?: boolean; // re-align the clone every frame when the lens itself moves (drag/animation)
+  // Directional + shape-adaptive refraction
+  angle?: number; // refraction direction in degrees (0 = baseline; positive = clockwise on screen)
+  shapeAdapt?: boolean; // aspect-faithful + isotropic refraction (default true); false = legacy map
+  // Lens field shape + manual tuning
+  lens?: LensMode; // 'classic' | 'convex' | 'shift' | 'rim'
+  lensStrength?: number; // manual magnitude of the lens field (default 1)
+  lensCenter?: [number, number]; // normalized 0..1 center for convex/rim (default [0.5, 0.5])
+  // Real animated refraction (Chromium SVG path; gated to in-view + reduced-motion off)
+  liquid?: LiquidPreset | false; // 'ripple' | 'flow' | 'wobble'
+  liquidSpeed?: number; // motion rate multiplier (default 1)
+  liquidScale?: number; // distortion amplitude in px (default per preset)
 }
 
 function isSemiTransparentColor(input: string | undefined | null): boolean {
@@ -259,6 +273,14 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
   backdropSelector,
   mirrorScale = 26,
   track = false,
+  angle = 0,
+  shapeAdapt = true,
+  lens = 'classic',
+  lensStrength = 1,
+  lensCenter,
+  liquid = false,
+  liquidSpeed = 1,
+  liquidScale,
   ...props
 }: LiquidGlassProps, ref) {
   // Configuration based on mode
@@ -324,6 +346,7 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const mirrorHolderRef = useRef<HTMLDivElement | null>(null);
+  const turbRef = useRef<SVGFETurbulenceElement | null>(null);
   const [dimensions, setDimensions] = useState({
     width: DEFAULT_WIDTH,
     height: DEFAULT_HEIGHT
@@ -334,6 +357,8 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
   // Whether the element is on (or near) screen. Offscreen instances drop their expensive
   // backdrop-filter so a page with many glass cards only pays for the visible ones.
   const [isVisible, setIsVisible] = useState(true);
+  // Pause animated refraction when the user prefers reduced motion.
+  const [reducedMotion, setReducedMotion] = useState(false);
   const [effectiveTextColor, setEffectiveTextColor] = useState<string>(textOnLight);
   const textClassNameRef = useRef<string | null>(null);
   if (!textClassNameRef.current) {
@@ -519,6 +544,16 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
     return () => io.disconnect();
   }, []);
 
+  // Track prefers-reduced-motion so animated refraction can pause for it.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReducedMotion(mq.matches);
+    update();
+    mq.addEventListener?.('change', update);
+    return () => mq.removeEventListener?.('change', update);
+  }, []);
+
   // Auto-detect background and set text color for children; updates on resize/scroll/mutations
   useEffect(() => {
     if (!autoTextColor) return;
@@ -592,8 +627,12 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
     const quantStep = QUALITY_QUANTIZATION_STEPS[resolvedQuality] || 16;
     const { newwidth, newheight } = quantizedSize(width, height, divisor, quantStep);
 
-    // Shared cache key across instances to reuse identical displacement maps
-    const cacheKey = `q:${resolvedQuality}|w:${newwidth}|h:${newheight}|r:${config.radius}|b:${config.border}|l:${config.lightness}|a:${config.alpha}|d:${config.displace}`;
+    // Shared cache key across instances to reuse identical displacement maps. `angle` is
+    // normalized so 0/360/NaN/float-noise never spawn duplicate-look entries, and `shapeAdapt`
+    // is keyed so an adapted and a legacy map can never collide.
+    const normAngle = normalizeAngle(angle);
+    const lcKey = lensCenter ? `${lensCenter[0]},${lensCenter[1]}` : '0.5,0.5';
+    const cacheKey = `q:${resolvedQuality}|w:${newwidth}|h:${newheight}|r:${config.radius}|b:${config.border}|l:${config.lightness}|a:${config.alpha}|d:${config.displace}|ang:${normAngle}|sa:${shapeAdapt ? 1 : 0}|ln:${lens}|ls:${lensStrength}|lc:${lcKey}`;
     const cached = cacheGet(cacheKey);
     if (cached) return cached;
 
@@ -607,11 +646,16 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
       lightness: config.lightness,
       alpha: config.alpha,
       displace: config.displace,
-      blend: config.blend
+      blend: config.blend,
+      angle: normAngle,
+      shapeAdapt,
+      lens,
+      lensStrength,
+      lensCenter
     });
     cacheSet(cacheKey, uri);
     return uri;
-  }, [dimensions, config, resolvedQuality]);
+  }, [dimensions, config, resolvedQuality, angle, shapeAdapt, lens, lensStrength, lensCenter]);
 
   // Generate a unique ID for the SVG filter
   const uniqueFilterId = useId();
@@ -683,6 +727,37 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
     const base = (resolvedQuality === 'low' || isMobile || effectMode === 'blur') ? Math.min(cssBlur, 2) : cssBlur;
     return Math.max(0, base);
   })();
+
+  // Real animated refraction ("liquid"). Resolved here so the inline filter graph and the rAF
+  // driver agree on whether it's active. Gated: a valid preset, the SVG (Chromium) path, on-screen,
+  // and reduced-motion off. The amplitude is capped on mobile / low quality.
+  const liquidPreset = isLiquidPreset(liquid) ? liquid : null;
+  const liquidActive = !!liquidPreset && useSvgFilter && isVisible && !reducedMotion && effectMode !== 'off';
+  const liquidCfg = liquidPreset
+    ? liquidConfig(liquidPreset, {
+        speed: liquidSpeed,
+        scale: liquidScale,
+        maxScale: isMobile || resolvedQuality === 'low' ? 14 : undefined
+      })
+    : null;
+
+  // Animate the live turbulence node's baseFrequency off rAF — no per-frame React render and no
+  // displacement-map re-encode. Stops automatically when offscreen / reduced-motion / liquid off.
+  useEffect(() => {
+    if (!liquidActive || !liquidPreset) return;
+    const node = turbRef.current;
+    if (!node) return;
+    let raf = 0;
+    let start = 0;
+    const tick = (now: number) => {
+      if (!start) start = now;
+      const [bx, by] = liquidBaseFrequency(liquidPreset, (now - start) / 1000, liquidSpeed);
+      node.setAttribute('baseFrequency', `${bx} ${by}`);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [liquidActive, liquidPreset, liquidSpeed]);
 
   useImperativeHandle(ref, () => ({
     get element() {
@@ -826,9 +901,10 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
                     yChannelSelector={config.y}
                     result="output"
                   />
-                  <feGaussianBlur 
+                  <feGaussianBlur
                     in="output"
                     stdDeviation={feBlurStdDev}
+                    result={liquidActive ? 'lqBase' : undefined}
                   />
                 </>
               ) : (
@@ -890,9 +966,29 @@ export const LiquidGlass = forwardRef<LiquidGlassHandle, LiquidGlassProps>(funct
                     mode="screen"
                     result="output"
                   />
-                  <feGaussianBlur 
+                  <feGaussianBlur
                     in="output"
                     stdDeviation={feBlurStdDev}
+                    result={liquidActive ? 'lqBase' : undefined}
+                  />
+                </>
+              )}
+              {liquidActive && liquidCfg && (
+                <>
+                  <feTurbulence
+                    ref={turbRef}
+                    type="fractalNoise"
+                    baseFrequency={`${liquidCfg.baseFrequencyX} ${liquidCfg.baseFrequencyY}`}
+                    numOctaves={liquidCfg.numOctaves}
+                    seed={liquidCfg.seed}
+                    result="lqNoise"
+                  />
+                  <feDisplacementMap
+                    in="lqBase"
+                    in2="lqNoise"
+                    scale={liquidCfg.scale}
+                    xChannelSelector="R"
+                    yChannelSelector="G"
                   />
                 </>
               )}

--- a/src/interactive/index.d.ts
+++ b/src/interactive/index.d.ts
@@ -19,7 +19,15 @@ export declare function usePointerElastic(
   options?: PointerElasticOptions
 ): void;
 
-export interface LiquidGlassInteractiveProps extends LiquidGlassProps, PointerElasticOptions {}
+/** When the animated refraction runs: always, only on hover, or only while pressed. */
+export type LiquidTrigger = 'always' | 'hover' | 'press';
+
+export interface LiquidGlassInteractiveProps extends LiquidGlassProps, PointerElasticOptions {
+  /** When the animated refraction runs. `hover`/`press` are idle (zero cost) until interaction. @default 'always' */
+  liquidTrigger?: LiquidTrigger;
+  /** A refractive bump that distorts the backdrop toward the cursor. @default false */
+  followPointer?: boolean;
+}
 
 export declare const LiquidGlassInteractive: ForwardRefExoticComponent<
   LiquidGlassInteractiveProps & RefAttributes<LiquidGlassHandle>

--- a/src/interactive/index.tsx
+++ b/src/interactive/index.tsx
@@ -1,7 +1,42 @@
-import React, { useEffect, useRef, useImperativeHandle, forwardRef, type RefObject } from 'react';
+import React, { useEffect, useRef, useState, useId, useImperativeHandle, forwardRef, type RefObject } from 'react';
 import LiquidGlass, { type LiquidGlassProps, type LiquidGlassHandle } from '../index';
 import { stepSpring, isSettled, clamp, type SpringState } from './spring';
 import { resolveElasticOptions } from './options';
+
+/** When the animated refraction runs: always, only on hover, or only while pressed. */
+export type LiquidTrigger = 'always' | 'hover' | 'press';
+
+interface PointerState {
+  inside: boolean;
+  pressing: boolean;
+}
+
+/** Tracks coarse pointer state on the glass element (for liquidTrigger + followPointer gating). */
+function usePointerState(ref: RefObject<LiquidGlassHandle | null>, enabled: boolean): PointerState {
+  const [state, setState] = useState<PointerState>({ inside: false, pressing: false });
+  useEffect(() => {
+    if (!enabled) return;
+    const el = ref.current?.element;
+    if (!el) return;
+    const enter = () => setState((s) => ({ ...s, inside: true }));
+    const leave = () => setState({ inside: false, pressing: false });
+    const down = () => setState((s) => ({ ...s, pressing: true }));
+    const up = () => setState((s) => ({ ...s, pressing: false }));
+    el.addEventListener('pointerenter', enter);
+    el.addEventListener('pointerleave', leave);
+    el.addEventListener('pointercancel', leave);
+    el.addEventListener('pointerdown', down);
+    window.addEventListener('pointerup', up);
+    return () => {
+      el.removeEventListener('pointerenter', enter);
+      el.removeEventListener('pointerleave', leave);
+      el.removeEventListener('pointercancel', leave);
+      el.removeEventListener('pointerdown', down);
+      window.removeEventListener('pointerup', up);
+    };
+  }, [ref, enabled]);
+  return enabled ? state : { inside: false, pressing: false };
+}
 
 export interface PointerElasticOptions {
   /** How far the glass leans toward the cursor. 0 = rigid. Default 0.15. */
@@ -109,7 +144,12 @@ export function usePointerElastic(
   }, [ref, elasticity, maxShift, stiffness, damping, specular]);
 }
 
-export interface LiquidGlassInteractiveProps extends LiquidGlassProps, PointerElasticOptions {}
+export interface LiquidGlassInteractiveProps extends LiquidGlassProps, PointerElasticOptions {
+  /** When the animated refraction runs. `hover`/`press` are idle (zero cost) until interaction. Default 'always'. */
+  liquidTrigger?: LiquidTrigger;
+  /** A refractive bump that distorts the backdrop toward the cursor. Default false. */
+  followPointer?: boolean;
+}
 
 /**
  * LiquidGlass + pointer-reactive elasticity and a tracked specular highlight. Opt-in: import
@@ -117,15 +157,65 @@ export interface LiquidGlassInteractiveProps extends LiquidGlassProps, PointerEl
  */
 export const LiquidGlassInteractive = forwardRef<LiquidGlassHandle, LiquidGlassInteractiveProps>(
   function LiquidGlassInteractive(
-    { elasticity, maxShift, stiffness, damping, specular = true, children, ...props },
+    {
+      elasticity,
+      maxShift,
+      stiffness,
+      damping,
+      specular = true,
+      liquid = false,
+      liquidTrigger = 'always',
+      followPointer = false,
+      children,
+      ...props
+    },
     ref
   ) {
     const innerRef = useRef<LiquidGlassHandle | null>(null);
     useImperativeHandle(ref, () => innerRef.current as LiquidGlassHandle, []);
-    usePointerElastic(innerRef, { elasticity, maxShift, stiffness, damping, specular });
+    // followPointer needs the pointer vars too, so enable specular tracking when either is on.
+    usePointerElastic(innerRef, { elasticity, maxShift, stiffness, damping, specular: specular || followPointer });
+
+    // Pointer state drives both the trigger gating and the follow-pointer bump visibility.
+    const needsPointerState = liquidTrigger !== 'always' || followPointer;
+    const { inside, pressing } = usePointerState(innerRef, needsPointerState);
+    const engaged = liquidTrigger === 'always' || (liquidTrigger === 'hover' ? inside : pressing);
+    const resolvedLiquid = liquid && engaged ? liquid : false;
+
+    const bumpId = `lg-bump-${useId().replace(/[^a-zA-Z0-9_-]/g, '')}`;
 
     return (
-      <LiquidGlass ref={innerRef} {...props}>
+      <LiquidGlass ref={innerRef} liquid={resolvedLiquid} {...props}>
+        {followPointer && (
+          <>
+            <span
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                left: 'var(--lg-mx, 50%)',
+                top: 'var(--lg-my, 50%)',
+                width: 104,
+                height: 104,
+                marginLeft: -52,
+                marginTop: -52,
+                borderRadius: '50%',
+                pointerEvents: 'none',
+                zIndex: 4,
+                opacity: inside ? 1 : 0,
+                transition: 'left 120ms ease-out, top 120ms ease-out, opacity 180ms ease',
+                backdropFilter: `url(#${bumpId})`,
+                WebkitBackdropFilter: `url(#${bumpId})`,
+                boxShadow: 'inset 0 1px 2px rgba(255,255,255,0.5)'
+              }}
+            />
+            <svg width="0" height="0" style={{ position: 'absolute' }} aria-hidden="true">
+              <filter id={bumpId} x="-50%" y="-50%" width="200%" height="200%" colorInterpolationFilters="sRGB">
+                <feTurbulence type="fractalNoise" baseFrequency="0.02 0.02" numOctaves={2} seed={9} result="n" />
+                <feDisplacementMap in="SourceGraphic" in2="n" scale={22} xChannelSelector="R" yChannelSelector="G" />
+              </filter>
+            </svg>
+          </>
+        )}
         {specular && (
           <span
             aria-hidden="true"

--- a/src/web-component/index.ts
+++ b/src/web-component/index.ts
@@ -8,7 +8,8 @@
  *   <script type="module" src="…/simple-liquid-glass/web-component"></script>
  *   <liquid-glass radius="20" frost="0.15" style="width:320px;height:200px"> … </liquid-glass>
  */
-import { buildDisplacementDataUri } from '../core/displacementMap';
+import { buildDisplacementDataUri, normalizeAngle } from '../core/displacementMap';
+import { liquidConfig, liquidBaseFrequency, isLiquidPreset } from '../core/liquid';
 
 const TAG = 'liquid-glass';
 let uid = 0;
@@ -31,12 +32,13 @@ const SHEEN =
 
 export class LiquidGlassElement extends HTMLElement {
   static get observedAttributes(): string[] {
-    return ['radius', 'frost', 'blur', 'saturation', 'displace', 'scale', 'border-color', 'lightness', 'alpha'];
+    return ['radius', 'frost', 'blur', 'saturation', 'displace', 'scale', 'border-color', 'lightness', 'alpha', 'angle', 'shape-adapt', 'lens', 'lens-strength', 'lens-center', 'liquid', 'liquid-speed', 'liquid-scale'];
   }
 
   private readonly filterId = `lg-wc-${++uid}`;
   private readonly root: ShadowRoot;
   private ro?: ResizeObserver;
+  private liquidRaf = 0;
 
   constructor() {
     super();
@@ -53,6 +55,7 @@ export class LiquidGlassElement extends HTMLElement {
 
   disconnectedCallback(): void {
     this.ro?.disconnect();
+    if (this.liquidRaf) cancelAnimationFrame(this.liquidRaf);
   }
 
   attributeChangedCallback(): void {
@@ -70,6 +73,28 @@ export class LiquidGlassElement extends HTMLElement {
     const alpha = attrNum(this, 'alpha', 0.9);
     const border = 0.05;
     const borderColor = this.getAttribute('border-color') || 'rgba(120, 120, 120, 0.7)';
+    const angle = normalizeAngle(attrNum(this, 'angle', 0));
+    const shapeAdapt = this.getAttribute('shape-adapt') !== 'false';
+    const lensAttr = this.getAttribute('lens');
+    const lens = (['classic', 'convex', 'shift', 'rim'] as const).includes(lensAttr as never)
+      ? (lensAttr as 'classic' | 'convex' | 'shift' | 'rim')
+      : 'classic';
+    const lensStrength = attrNum(this, 'lens-strength', 1);
+    const lensCenterAttr = this.getAttribute('lens-center');
+    const lensCenter = (() => {
+      if (!lensCenterAttr) return undefined;
+      const parts = lensCenterAttr.split(/[ ,]+/).map(parseFloat);
+      return parts.length === 2 && parts.every(Number.isFinite) ? ([parts[0], parts[1]] as [number, number]) : undefined;
+    })();
+    const liquidAttr = this.getAttribute('liquid');
+    const liquidPreset = isLiquidPreset(liquidAttr) ? liquidAttr : null;
+    const liquidSpeed = attrNum(this, 'liquid-speed', 1);
+    const liquidScale = this.getAttribute('liquid-scale') != null ? attrNum(this, 'liquid-scale', NaN) : undefined;
+    const reduce =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const liquidActive = !!liquidPreset && !reduce;
 
     const r = this.getBoundingClientRect();
     const width = r.width || 300;
@@ -83,11 +108,18 @@ export class LiquidGlassElement extends HTMLElement {
 
     if (chromium) {
       const uri = buildDisplacementDataUri({
-        width, height, divisor: 3, quantStep: 24, radius, border, lightness, alpha, displace, blend: 'difference'
+        width, height, divisor: 3, quantStep: 24, radius, border, lightness, alpha, displace, blend: 'difference', angle, shapeAdapt, lens, lensStrength, lensCenter
       });
       backdrop = `saturate(${saturation}%) url(#${this.filterId})`;
       glassBg = `hsl(0 0% 100% / ${frost})`;
-      svg = `<svg width="0" height="0" style="position:absolute" aria-hidden="true"><filter id="${this.filterId}" color-interpolation-filters="sRGB"><feImage href="${uri}" x="0" y="0" width="100%" height="100%" result="map"/><feDisplacementMap in="SourceGraphic" in2="map" scale="${scale}" xChannelSelector="R" yChannelSelector="B" result="out"/><feGaussianBlur in="out" stdDeviation="${blur}"/></filter></svg>`;
+      let blurResult = '';
+      let lqStage = '';
+      if (liquidActive && liquidPreset) {
+        const cfg = liquidConfig(liquidPreset, { speed: liquidSpeed, scale: liquidScale });
+        blurResult = ' result="lqBase"';
+        lqStage = `<feTurbulence type="fractalNoise" baseFrequency="${cfg.baseFrequencyX} ${cfg.baseFrequencyY}" numOctaves="${cfg.numOctaves}" seed="${cfg.seed}" result="lqNoise" data-lg-turb="1"/><feDisplacementMap in="lqBase" in2="lqNoise" scale="${cfg.scale}" xChannelSelector="R" yChannelSelector="G"/>`;
+      }
+      svg = `<svg width="0" height="0" style="position:absolute" aria-hidden="true"><filter id="${this.filterId}" color-interpolation-filters="sRGB"><feImage href="${uri}" x="0" y="0" width="100%" height="100%" result="map"/><feDisplacementMap in="SourceGraphic" in2="map" scale="${scale}" xChannelSelector="R" yChannelSelector="B" result="out"/><feGaussianBlur in="out" stdDeviation="${blur}"${blurResult}/>${lqStage}</filter></svg>`;
     } else {
       const frostPx = Math.max(blur, 9);
       backdrop = `blur(${frostPx}px) saturate(${Math.max(saturation, 160)}%) brightness(1.04)`;
@@ -111,6 +143,25 @@ export class LiquidGlassElement extends HTMLElement {
       <div class="lg-content"><slot></slot></div>
       ${svg}
     `;
+
+    // The shadow DOM was just rebuilt, so any prior rAF points at a detached node — restart it.
+    if (this.liquidRaf) {
+      cancelAnimationFrame(this.liquidRaf);
+      this.liquidRaf = 0;
+    }
+    if (liquidActive && liquidPreset) {
+      const turb = this.root.querySelector('[data-lg-turb]') as SVGFETurbulenceElement | null;
+      if (turb) {
+        let startT = 0;
+        const tick = (now: number) => {
+          if (!startT) startT = now;
+          const [bx, by] = liquidBaseFrequency(liquidPreset, (now - startT) / 1000, liquidSpeed);
+          turb.setAttribute('baseFrequency', `${bx} ${by}`);
+          this.liquidRaf = requestAnimationFrame(tick);
+        };
+        this.liquidRaf = requestAnimationFrame(tick);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

**3.0.0** — adds directional + shape-adaptive refraction, four lens field modes with manual tuning, and real animated/interactive "liquid" refraction. All on the Chromium SVG-displacement path; fallback engines (Safari/iOS/Firefox) keep the existing mirror unchanged.

## Added

- **`shapeAdapt`** (default **on**) — the displacement map is built in aspect-true pixel space + isotropic amplitude, so a long navbar / tall sidebar reads like glass *cut to its shape* instead of over-bending on the short axis. `shapeAdapt={false}` restores the byte-identical legacy ≤2.x map.
- **`angle`** (deg) — directional refraction lean, faithful on any aspect ratio (`0` = baseline; positive = clockwise). For `lens: 'shift'` it's the offset direction.
- **`lens`** — four field modes: `classic` (linear radial), `convex` (one coherent dome magnifier — no top/bottom split), `shift` (uniform directional offset; straight lines stay straight), `rim` (clear flat center, refraction only at a soft perimeter band). Manual tuning via **`lensStrength`** and **`lensCenter`**.
- **`liquid`** — real animated refraction presets `ripple | flow | wobble` (live `feTurbulence` → `feDisplacementMap`, rAF-driven) + **`liquidSpeed`** / **`liquidScale`**. Opt-in and GPU-gated: animates only while on-screen, pauses on `prefers-reduced-motion`, Chromium-only, amplitude-capped on mobile/low quality.
- **`LiquidGlassInteractive`**: **`liquidTrigger`** (`always | hover | press` — idle/zero-cost until interaction) and **`followPointer`** (a refractive bump that distorts toward the cursor).
- New shared core: `src/core/liquid.ts` and `normalizeAngle` in `src/core/displacementMap.ts`.

## Breaking change

`shapeAdapt` defaults to `true`, which changes how **non-square** lenses refract at `angle: 0` (square lenses are visually unchanged). Set `shapeAdapt={false}` for the legacy look.

## Verification

- Build clean across all 4 entry points; **62/62 unit tests** pass (new coverage for angle/normalize/shapeAdapt/lens modes/liquid presets).
- `size-limit` green — budgets raised to fit (~2.3 KB gzip of new features; React core ~7.5 → ~9.8 KB). README/package.json size claims updated "~6.5 KB" → "~10 KB core / ~5 KB web component" (still far under competitors).
- Lens-mode displacement math was derived + adversarially channel-math-verified before implementation (caught and fixed a convex sign inversion and a rim fold bug). All four modes confirmed fold-free on real Chromium renders at the default `scale`.

## Notes

- Docs updated: README prop table, all framework guides (vue/svelte/astro/vanilla + index), Storybook controls.
- `examples/` pins published `^1.0.3`, so its Vercel deploy won't reflect 3.0.0 until that dependency is bumped post-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)